### PR TITLE
v2.4.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+master (unreleased)
+-------------------
+
+Nothing here yet.
+
 2.4.0 (2018-03-28)
 ------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,20 +1,31 @@
 CHANGELOG
 =========
 
-master (unreleased)
--------------------
+2.4.0 (2018-03-28)
+------------------
 
-- Dropped support for Python 3.3 (#245).
+New Calendars
+~~~~~~~~~~~~~
+
+- Added Lithuania, by @landler (#254).
+- Added Russia, by @vanadium23 (#259).
+
+Bugfixes
+~~~~~~~~
+
+- Fixed shifting ANZAC day for Australia states (#249).
+- Renamed Australian state classes to actual state names(eg. AustraliaNewSouthWales to NewSouthWales).
+- Update ACT holidays (#251).
+- Fixing Federal Christmas Shift ; added a `include_veterans_day` flag to enable/disable Veteran's day on specific calendar - e.g. Mozilla's dedicated calendar (#242).
+
+Other
+~~~~~
+
+- **Deprecation:** Dropped support for Python 3.3 (#245).
 - Fixed Travis-ci configuration for Python 3.5 and al (#252).
-- Fixed shifting ANZAC day for Australia states(#249)
-- Renamed Australian state classes to actual state names(eg. AustraliaNewSouthWales to NewSouthWales)
-- Update ACT holidays( #251)
+- Moved from `novafloss` to the `peopledoc` organization, the core People Doc Inc. organization (#255).
 - First step iteration on the "global registry" feature. European countries are now part of a registry loaded in the ``workalenda.registry`` module. Please use with care at the moment (#248).
-- Moved from `novafloss` to the `peopledoc` organization, the core People Doc Inc. organization (#255)
-- Fixing Federal Christmas Shift ; added a `include_veterans_day` flag to enable/disable Veteran's day on specific calendar - e.g. Mozilla's dedicated calendar (#242)
-- Refactored Australia family and community day calculation (#244)
-- Added Lithuania, by @landler (#254)
-- Added Russia, by @vanadium23 (#259)
+- Refactored Australia family and community day calculation (#244).
 
 2.3.1 (2017-07-27)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ REQUIREMENTS = [
     'pyCalverter',
     'setuptools>=1.0',
 ]
-version = '2.4.0'
+version = '2.5.0.dev0'
 __VERSION__ = version
 
 if PY2:

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ REQUIREMENTS = [
     'pyCalverter',
     'setuptools>=1.0',
 ]
-version = '2.4.0.dev0'
+version = '2.4.0'
 __VERSION__ = version
 
 if PY2:


### PR DESCRIPTION

### New Calendars

- Added Lithuania, by @landler (#254).
- Added Russia, by @vanadium23 (#259).

### Bugfixes

- Fixed shifting ANZAC day for Australia states (#249).
- Renamed Australian state classes to actual state names(eg. AustraliaNewSouthWales to NewSouthWales).
- Update ACT holidays (#251).
- Fixing Federal Christmas Shift ; added a `include_veterans_day` flag to enable/disable Veteran's day on specific calendar - e.g. Mozilla's dedicated calendar (#242).

### Other

- **Deprecation:** Dropped support for Python 3.3 (#245).
- Fixed Travis-ci configuration for Python 3.5 and al (#252).
- Moved from `novafloss` to the `peopledoc` organization, the core People Doc Inc. organization (#255).
- First step iteration on the "global registry" feature. European countries are now part of a registry loaded in the ``workalenda.registry`` module. Please use with care at the moment (#248).
- Refactored Australia family and community day calculation (#244).
