### PR TITLE
De-duplicate South Africa holidays

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ CHANGELOG
 master (unreleased)
 -------------------
 
-Nothing here yet.
+* Bugfix: deduplicate South Africa holidays that were emitted as duplicates (#265).
 
 2.4.0 (2018-03-28)
 ------------------

--- a/workalendar/africa/south_africa.py
+++ b/workalendar/africa/south_africa.py
@@ -58,7 +58,10 @@ class SouthAfrica(WesternCalendar, ChristianMixin):
     def get_variable_days(self, year):
         days = super(SouthAfrica, self).get_variable_days(year)
         days.append(self.get_family_day(year))
-        days += self.get_fixed_holidays(year)
+        return days
+
+    def get_calendar_holidays(self, year):
+        days = super(SouthAfrica, self).get_calendar_holidays(year)
         # compute shifting days
         for holiday, label in days:
             if holiday.weekday() == SUN:

--- a/workalendar/tests/test_africa.py
+++ b/workalendar/tests/test_africa.py
@@ -70,12 +70,6 @@ class SouthAfricaTest(GenericCalendarTest):
         self.assertIn(date(2014, 4, 27), holidays)  # freedom day
         self.assertIn(date(2014, 4, 28), holidays)  # freedom day sub
 
-#    def test_pre_1994(self):
-#        pass
-#
-#    def test_pre_1995(self):
-#        pass
-
     def test_special_1999(self):
         # National and provincial government elections – 2 June 1999[8]
         holidays = self.cal.holidays_set(1999)
@@ -152,6 +146,11 @@ class SouthAfricaTest(GenericCalendarTest):
         # 2nd Monday in July	Queen's Birthday	1952–1960
         holidays = self.cal.holidays_set(1960)
         self.assertIn(date(1960, 5, 2), holidays)
+
+    def test_remove_duplicates(self):
+        holidays = self.cal.holidays(2014)
+        dates = ["{} {}".format(x, y) for x, y in holidays]
+        self.assertEqual(len(dates), len(set(dates)))
 
 
 class Madagascar(GenericCalendarTest):


### PR DESCRIPTION
refs #265

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes.
