### PR TITLE
Fixed usage examples of ``get_first_weekday_after()`` docstring + in code (calendars and tests)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ master (unreleased)
 
 - Allow the `add_working_days()` function to be provided a datetime, and returning a `date` (#270).
 - Added a `keep_datetime` option to keep the original type of the input argument for both ``add_working_days()`` and ``sub_working_days()`` functions (#270).
+- Fixed usage examples of ``get_first_weekday_after()`` docstring + in code (calendars and tests) ; do not use magic values, use MON, TUE, etc (#271).
 
 2.5.0 (2018-06-14)
 ------------------

--- a/workalendar/america/colombia.py
+++ b/workalendar/america/colombia.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from datetime import timedelta, date
 
-from workalendar.core import WesternCalendar, ChristianMixin
+from workalendar.core import WesternCalendar, ChristianMixin, MON
 
 
 class Colombia(WesternCalendar, ChristianMixin):
@@ -23,11 +23,11 @@ class Colombia(WesternCalendar, ChristianMixin):
 
     def get_epiphany(self, year):
         base_day = date(year, 1, 6)
-        return Colombia.get_first_weekday_after(base_day, 0)
+        return Colombia.get_first_weekday_after(base_day, MON)
 
     def get_saint_joseph(self, year):
         base_day = date(year, 3, 19)
-        return Colombia.get_first_weekday_after(base_day, 0)
+        return Colombia.get_first_weekday_after(base_day, MON)
 
     def get_ascension(self, year):
         return self.get_easter_sunday(year) + timedelta(days=43)
@@ -40,23 +40,23 @@ class Colombia(WesternCalendar, ChristianMixin):
 
     def get_saint_peter_and_saint_paul(self, year):
         base_day = date(year, 6, 29)
-        return Colombia.get_first_weekday_after(base_day, 0)
+        return Colombia.get_first_weekday_after(base_day, MON)
 
     def get_assumption(self, year):
         base_day = date(year, 8, 15)
-        return Colombia.get_first_weekday_after(base_day, 0)
+        return Colombia.get_first_weekday_after(base_day, MON)
 
     def get_race_day(self, year):
         base_day = date(year, 10, 12)
-        return Colombia.get_first_weekday_after(base_day, 0)
+        return Colombia.get_first_weekday_after(base_day, MON)
 
     def get_all_saints(self, year):
         base_day = date(year, 11, 1)
-        return Colombia.get_first_weekday_after(base_day, 0)
+        return Colombia.get_first_weekday_after(base_day, MON)
 
     def get_cartagena_independence(self, year):
         base_day = date(year, 11, 11)
-        return Colombia.get_first_weekday_after(base_day, 0)
+        return Colombia.get_first_weekday_after(base_day, MON)
 
     def get_variable_days(self, year):
         days = super(Colombia, self).get_variable_days(year)

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -249,11 +249,11 @@ class Calendar(object):
         weekday, the same day will be returned.
 
         >>> # the first monday after Apr 1 2015
-        >>> Calendar.get_first_weekday_after(date(2015, 4, 1), 0)
+        >>> Calendar.get_first_weekday_after(date(2015, 4, 1), MON)
         datetime.date(2015, 4, 6)
 
         >>> # the first tuesday after Apr 14 2015
-        >>> Calendar.get_first_weekday_after(date(2015, 4, 14), 1)
+        >>> Calendar.get_first_weekday_after(date(2015, 4, 14), TUE)
         datetime.date(2015, 4, 14)
         """
         day_delta = (weekday - day.weekday()) % 7

--- a/workalendar/tests/test_core.py
+++ b/workalendar/tests/test_core.py
@@ -89,13 +89,13 @@ class CalendarTest(GenericCalendarTest):
     def test_get_next_weekday_after(self):
         # the first monday after Apr 1 2015
         self.assertEquals(
-            Calendar.get_first_weekday_after(date(2015, 4, 1), 0),
+            Calendar.get_first_weekday_after(date(2015, 4, 1), MON),
             date(2015, 4, 6)
         )
 
         # the first tuesday after Apr 14 2015
         self.assertEquals(
-            Calendar.get_first_weekday_after(date(2015, 4, 14), 1),
+            Calendar.get_first_weekday_after(date(2015, 4, 14), TUE),
             date(2015, 4, 14)
         )
 


### PR DESCRIPTION
- [x] Tests with a significant number of years to be tested for your calendar. (tests are almost unchanged)
- [x] Changelog amended with a mention describing your changes.
