### PR TITLE
Add Angola, fix Portugal holidays, All Souls' Day

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,9 @@
 # CHANGELOG
 
 ## master (unreleased)
-
+- Added Angola, by @dvdmgl (#276)
+- Portugal - removed carnival from Portuguese holidays, restored missing holidays (#275)
+- Added All Souls Day to common (#274)
 - Allow the `add_working_days()` function to be provided a datetime, and returning a `date` (#270).
 - Added a `keep_datetime` option to keep the original type of the input argument for both ``add_working_days()`` and ``sub_working_days()`` functions (#270).
 - Fixed usage examples of ``get_first_weekday_after()`` docstring + in code (calendars and tests) ; do not use magic values, use MON, TUE, etc (#271).

--- a/README.rst
+++ b/README.rst
@@ -144,6 +144,7 @@ Africa
 ------
 
 * Algeria
+* Angola
 * Benin
 * Ivory Coast
 * Madagascar

--- a/workalendar/africa/__init__.py
+++ b/workalendar/africa/__init__.py
@@ -8,6 +8,7 @@ from .ivory_coast import IvoryCoast
 from .madagascar import Madagascar
 from .sao_tome import SaoTomeAndPrincipe
 from .south_africa import SouthAfrica
+from .angola import Angola
 
 
 __all__ = (
@@ -17,4 +18,5 @@ __all__ = (
     'Madagascar',
     'SaoTomeAndPrincipe',
     'SouthAfrica',
+    'Angola',
 )

--- a/workalendar/africa/angola.py
+++ b/workalendar/africa/angola.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from datetime import timedelta
+from workalendar.core import WesternCalendar
+from workalendar.core import ChristianMixin
+from workalendar.registry import iso_register
+
+
+@iso_register('AO')
+class Angola(WesternCalendar, ChristianMixin):
+    name = 'Angola'
+
+    include_good_friday = True
+    include_easter_sunday = True
+    include_christmas = True
+    include_all_souls = True
+
+    FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
+        (2, 4, "Dia do Inicio da Luta Armada"),
+        (3, 8, "Dia Internacional da Mulher"),
+        (4, 4, "Dia da Paz"),
+        (5, 1, "Dia Internacional do Trabalhador"),
+        (9, 17, "Dia do Fundador da Nação e do Herói Nacional"),
+        (11, 11, "Dia da Independência Nacional"),
+    )
+
+    def get_variable_entrudo(self, year):
+        easter_sunday = self.get_easter_sunday(year)
+        return easter_sunday - timedelta(days=47)
+
+    def get_variable_days(self, year):
+        days = super(Angola, self).get_variable_days(year)
+        days.append((self.get_variable_entrudo(year), "Dia de Carnaval"))
+        return days

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -333,6 +333,7 @@ class ChristianMixin(Calendar):
     include_corpus_christi = False
     include_boxing_day = False
     boxing_day_label = "Boxing Day"
+    include_all_souls = False
 
     def get_ash_wednesday(self, year):
         sunday = self.get_easter_sunday(year)
@@ -432,6 +433,8 @@ class ChristianMixin(Calendar):
             days.append((date(year, 8, 15), "Assumption of Mary to Heaven"))
         if self.include_all_saints:
             days.append((date(year, 11, 1), "All Saints Day"))
+        if self.include_all_souls:
+            days.append((date(year, 11, 2), "All Souls Day"))
         if self.include_immaculate_conception:
             days.append((date(year, 12, 8), "Immaculate Conception"))
         if self.include_christmas:

--- a/workalendar/europe/portugal.py
+++ b/workalendar/europe/portugal.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from datetime import timedelta
+from datetime import date
 from workalendar.core import WesternCalendar, ChristianMixin
 from workalendar.registry import iso_register
 
@@ -11,6 +11,7 @@ class Portugal(WesternCalendar, ChristianMixin):
 
     include_good_friday = True
     include_easter_sunday = True
+    include_christmas = True
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (4, 25, "Dia da Liberdade"),
@@ -20,11 +21,17 @@ class Portugal(WesternCalendar, ChristianMixin):
         (12, 8, "Imaculada Conceição"),
     )
 
-    def get_variable_entrudo(self, year):
-        easter_sunday = self.get_easter_sunday(year)
-        return easter_sunday - timedelta(days=47)
+    def get_fixed_holidays(self, year):
+        days = super(Portugal, self).get_fixed_holidays(year)
+        if year > 2015 or year < 2013:
+
+            days.append((date(year, 10, 5), "Implantação da República"))
+            days.append((date(year, 11, 1), "Todos os santos"))
+            days.append((date(year, 12, 1), "Restauração da Independência"))
+        return days
 
     def get_variable_days(self, year):
         days = super(Portugal, self).get_variable_days(year)
-        days.append((self.get_variable_entrudo(year), "Entrudo"))
+        if year > 2015 or year < 2013:
+            days.append((self.get_corpus_christi(year), "Corpus Christi"))
         return days

--- a/workalendar/tests/test_africa.py
+++ b/workalendar/tests/test_africa.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
 from datetime import date
 from workalendar.tests import GenericCalendarTest
-from workalendar.africa import Benin, Algeria
-from workalendar.africa import SouthAfrica, IvoryCoast
-from workalendar.africa import SaoTomeAndPrincipe, Madagascar
+from workalendar.africa import (
+    Algeria,
+    Angola,
+    Benin,
+    IvoryCoast,
+    Madagascar,
+    SaoTomeAndPrincipe,
+    SouthAfrica,
+)
 from workalendar.core import MON
 
 
@@ -207,3 +213,33 @@ class SaoTomeAndPrincipeTest(GenericCalendarTest):
         self.assertIn(date(2013, 11, 1), holidays)  # All saints
         self.assertIn(date(2013, 12, 21), holidays)  # São Tomé Day
         self.assertIn(date(2013, 12, 25), holidays)  # XMas
+
+
+class AngolaTest(GenericCalendarTest):
+    cal_class = Angola
+
+    def test_year_2018(self):
+        holidays = self.cal.holidays_set(2018)
+        # Dia de Ano Novo – 1 de Janeiro
+        self.assertIn(date(2018, 1, 1), holidays)  # Ano Novo
+        # Dia do Inicio da Luta Armada – 4 de Fevereiro
+        self.assertIn(date(2018, 2, 4), holidays)
+        # Dia do Carnaval – 13 de Fevereiro
+        self.assertIn(date(2018, 2, 13), holidays)  # Entrudo
+        # Dia Internacional da Mulher – 8 de Março
+        self.assertIn(date(2018, 3, 8), holidays)
+        # Dia da Paz – 4 de Abril
+        self.assertIn(date(2018, 4, 4), holidays)  # Dia da Paz
+        # Sexta Feira Santa – 30 de Março
+        self.assertIn(date(2018, 3, 30), holidays)  # Sexta-Feira Santa
+        # Páscoa – 01 de Abril
+        self.assertIn(date(2018, 4, 1), holidays)  # Domingo de Páscoa
+        # Dia Internacional do Trabalhador – 1 de Maio
+        self.assertIn(date(2018, 5, 1), holidays)  # Dia do Trabalhador
+        # Dia do Fundador da Nação e do Herói Nacional – 17 de Setembro
+        self.assertIn(date(2018, 9, 17), holidays)
+        # Dia dos Finados – 2 de Novembro
+        # Dia da Independência Nacional – 11 de Novembro
+        self.assertIn(date(2018, 11, 11), holidays)
+        # Dia do Natal – 25 de Dezembro
+        self.assertIn(date(2018, 12, 25), holidays)  # Natal

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -1058,7 +1058,6 @@ class PortugalTest(GenericCalendarTest):
     def test_year_2015(self):
         holidays = self.cal.holidays_set(2015)
         self.assertIn(date(2015, 1, 1), holidays)  # Ano Novo
-        self.assertIn(date(2015, 2, 17), holidays)  # Entrudo
         self.assertIn(date(2015, 4, 3), holidays)  # Sexta-Feira Santa
         self.assertIn(date(2015, 4, 5), holidays)  # Domingo de Páscoa
         self.assertIn(date(2015, 4, 25), holidays)  # Dia da Liberdade
@@ -1068,10 +1067,15 @@ class PortugalTest(GenericCalendarTest):
         self.assertIn(date(2015, 12, 8), holidays)  # Imaculada Conceição
         self.assertIn(date(2015, 12, 25), holidays)  # Natal
 
+        self.assertNotIn(date(2015, 6, 4), holidays)  # Corpus Christi
+        self.assertNotIn(date(2015, 10, 5), holidays)  # Todos os santos
+        self.assertNotIn(date(2015, 11, 1), holidays)  # todos os santos
+        # Restauração da Independência
+        self.assertNotIn(date(2015, 12, 1), holidays)
+
     def test_year_2016(self):
         holidays = self.cal.holidays_set(2016)
         self.assertIn(date(2016, 1, 1), holidays)  # Ano Novo
-        self.assertIn(date(2016, 2, 9), holidays)  # Entrudo
         self.assertIn(date(2016, 3, 25), holidays)  # Sexta-Feira Santa
         self.assertIn(date(2016, 3, 27), holidays)  # Domingo de Páscoa
         self.assertIn(date(2016, 4, 25), holidays)  # Dia da Liberdade
@@ -1080,6 +1084,12 @@ class PortugalTest(GenericCalendarTest):
         self.assertIn(date(2016, 8, 15), holidays)  # Assunção de Nossa Senhora
         self.assertIn(date(2016, 12, 8), holidays)  # Imaculada Conceição
         self.assertIn(date(2016, 12, 25), holidays)  # Natal
+
+        self.assertIn(date(2016, 5, 26), holidays)  # Corpus Christi
+        self.assertIn(date(2016, 10, 5), holidays)  # Implantação da República
+        self.assertIn(date(2016, 11, 1), holidays)  # Todos os santos
+        # Restauração da Independência
+        self.assertIn(date(2016, 12, 1), holidays)
 
 
 class SpainTest(GenericCalendarTest):


### PR DESCRIPTION
refs #276 

- Adds Angola holidays

<!-- if your contribution is a new calendar -->

For information, read and make sure you're okay with the [CONTRIBUTING document](https://github.com/novafloss/workalendar/blob/master/CONTRIBUTING.rst#adding-new-calendars).

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Docstrings for the Calendar class and specific methods.
- [x] Calendar country / label added to the README.rst file,
- [x] Changelog amended with a mention like: "Added ``<country>`` by ``@pseudo`` (#)"

<!-- if your contribution is a fix -->
- Restores Portugal holidays that were of by 2013 to 2015. [wikipedia pt](https://pt.wikipedia.org/wiki/Feriados_em_Portugal#Feriados_eliminados_em_2013%E2%80%932015) [wikipedia en](https://en.wikipedia.org/wiki/Public_holidays_in_Portugal#Revoked_holidays_in_2013%E2%80%932015)
- Fixes Portugal holidays as carnival in not a national holiday (in some regions and some companies, and public workers sometimes get a break);

- Adds All Souls' Day to common [wikipedia](https://en.wikipedia.org/wiki/All_Souls%27_Day)

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes.

This closes #276 , closes #275 , closes #274 .