### PR TITLE
Add Israel calendar

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,10 @@ Large work on global registry: refs #13, #96 & #257.
 - You don't have to declare a `name` properties for Calendar classes. It will be deducted from the docstring.
 - Changed the `registry.items()` mandatory argument name to `region_codes` for more readability.
 
+## v2.7.0 (2018-09-09)
+
+- Added Israel, by @armona, @tsehori (#281)
+
 ## v2.6.0 (2018-08-30)
 
 ### New Calendars
@@ -31,8 +35,8 @@ Large work on global registry: refs #13, #96 & #257.
 
 - Added All Souls Day to common (#274)
 - Allow the `add_working_days()` function to be provided a datetime, and returning a `date` (#270).
-- Added a `keep_datetime` option to keep the original type of the input argument for both ``add_working_days()`` and ``sub_working_days()`` functions (#270).
-- Fixed usage examples of ``get_first_weekday_after()`` docstring + in code (calendars and tests) ; do not use magic values, use MON, TUE, etc (#271).
+- Added a `keep_datetime` option to keep the original type of the input argument for both `add_working_days()` and `sub_working_days()` functions (#270).
+- Fixed usage examples of `get_first_weekday_after()` docstring + in code (calendars and tests) ; do not use magic values, use MON, TUE, etc (#271).
 - Turned Changelog into a Markdown file (#272).
 - Added basic usage documentation, hosted by Github pages.
 - Added advanced usage documentation.
@@ -61,7 +65,7 @@ Large work on global registry: refs #13, #96 & #257.
 - **Deprecation:** Dropped support for Python 3.3 (#245).
 - Fixed Travis-ci configuration for Python 3.5 and al (#252).
 - Moved from `novafloss` to the `peopledoc` organization, the core People Doc Inc. organization (#255).
-- First step iteration on the "global registry" feature. European countries are now part of a registry loaded in the ``workalendar.registry`` module. Please use with care at the moment (#248).
+- First step iteration on the "global registry" feature. European countries are now part of a registry loaded in the `workalendar.registry` module. Please use with care at the moment (#248).
 - Refactored Australia family and community day calculation (#244).
 
 ## v2.3.1 (2017-07-27)
@@ -89,7 +93,7 @@ I have done a terrible mistake with the 1.3.0 release, and uploaded a defunct 2.
 - Added Singapore calendar, initiated by @nedlowe (#194 + #195).
 - Added Malaysia, by @gregyhj (#201).
 - Added Good Friday in the list of Hungarian holidays, as of the year 2017 (#203), thx to @mariusz-korzekwa for the bug report.
-- Assigned a minimal setuptools version, to avoid naughty ``DistributionNotFound`` exceptions with obsolete versions (#74).
+- Assigned a minimal setuptools version, to avoid naughty `DistributionNotFound` exceptions with obsolete versions (#74).
 - Fixed a bug in Slovakia calendar, de-duplicated Christmas Day, that appeared twice (#205).
 - Fixed important bugs in the calendars of the following Brazilian cities: Vitória, Vila Velha, Cariacica, Guarapari and Serra - thx to Fernanda Gonçalves Rodrigues, who confirmed this issue raised by @Skippern (#199).
 
@@ -98,8 +102,8 @@ I have done a terrible mistake with the 1.3.0 release, and uploaded a defunct 2.
 - Moved all the calendar of countries on the american continent in their own modules (#188).
 - Refactor base Calendar class get_weekend_days to use WEEKEND_DAYS more intelligently (#191 + #192).
 - Many additions to the Brazil and various states / cities. Were added: Acre, Alagoas, Amapá, Amazonas, Bahia, Ceará, Distrito Federal, Espírito Santo State, Goiás, Maranhão, Mato Grosso, Mato Grosso do Sul, Pará, Paraíba, Pernambuco, Piauí, Rio de Janeiro, Rio Grande do Norte, Rio Grande do Sul, Rondônia, Roraima, Santa Catarina, São Paulo, Sergipe, Tocantins, City of Vitória, City of Vila Velha, City of Cariacica, City of Guarapari and City of Serra (#187).
-- Added a ``good_friday_label`` class variable to ``ChristianMixin`` ; one can assign the right label to this holiday (#187).
-- Added a ``ash_wednesday_label`` class variable to ``ChristianMixin`` ; one can assign the right label to this holiday (#187).
+- Added a `good_friday_label` class variable to `ChristianMixin` ; one can assign the right label to this holiday (#187).
+- Added a `ash_wednesday_label` class variable to `ChristianMixin` ; one can assign the right label to this holiday (#187).
 
 ## v1.1.0 (2017-02-28)
 
@@ -119,7 +123,7 @@ After several years of development, we can now say that this library is producti
 
 - Add Ireland. thx @gregn610 (#152).
 - Bugfix: New Year's Eve is not a holiday in Netherlands (#154).
-- Add Austria.  thx @gregn610 (#153)
+- Add Austria. thx @gregn610 (#153)
 - Add Bulgaria. thx @gregn610 (#156)
 - Add Croatia. thx @gregn610 (#157)
 
@@ -137,7 +141,7 @@ After several years of development, we can now say that this library is producti
 - Added Catalonia (#145), thx @ferranp.
 - Use `find_packages()` to fetch package directories in `setup.py` (#141, #144).
 - use py.test instead of nosetests for tests (#146).
-- cleanup: remove unused ``swiss.py`` file (#147).
+- cleanup: remove unused `swiss.py` file (#147).
 
 ## v0.6.1 (2016-06-29)
 
@@ -147,7 +151,7 @@ After several years of development, we can now say that this library is producti
 - Added a pull-request template (#125),
 - Added a Makefile for various dev-related tasks -- installs, running tests, uploading to PyPI... (#133).
 
-*Note:* the 0.6.0 was erroneously uploaded ; this v0.6.1 cancels and replaces the v0.6.0.
+_Note:_ the 0.6.0 was erroneously uploaded ; this v0.6.1 cancels and replaces the v0.6.0.
 
 ## v0.5.0 (2016-06-14)
 
@@ -164,7 +168,7 @@ After several years of development, we can now say that this library is producti
 **Sorry, I think I completely broke the 0.4.3 release by trying to delete a naughty file...**
 
 - Added Denmark (#117).
-- Tiny fixes in the ``usa.py`` module (flake8 + typo) (#122)
+- Tiny fixes in the `usa.py` module (flake8 + typo) (#122)
 - Added datetime to date conversion in is_holiday() (#118)
 - Added function to get the holiday label by date (#120)
 - Moved from `novapost` to the `novafloss` organization, handling FLOSS projects in People Doc Inc. (#116)
@@ -192,8 +196,8 @@ After several years of development, we can now say that this library is producti
 - Germany calendar added, thx to @rndusr
 - Support building on systems where LANG=C (Ubuntu) #92
 - little improvement to directly return a tested value.
-- ``delta`` argument for ``add_working_days()`` can be negative. added a
-  ``sub_working_days()`` method that computes working days backwards.
+- `delta` argument for `add_working_days()` can be negative. added a
+  `sub_working_days()` method that computes working days backwards.
 - BUGFIX: shifting UK boxing day if Christmas day falls on a Friday (shit to
   next Monday) #95
 - BUGFIX: Renaming the Finnish "Independance Day" #101 (thx to

--- a/README.rst
+++ b/README.rst
@@ -133,6 +133,7 @@ Asia
 * Singapore
 * South Korea
 * Taiwan
+* Israel
 
 Oceania
 -------

--- a/setup.py
+++ b/setup.py
@@ -12,53 +12,54 @@ def read_relative_file(filename):
     """Returns contents of the given file, whose path is supposed relative
     to this module."""
     path = join(dirname(abspath(__file__)), filename)
-    with io.open(path, encoding='utf-8') as f:
+    with io.open(path, encoding="utf-8") as f:
         return f.read()
 
 
-NAME = 'workalendar'
-DESCRIPTION = 'Worldwide holidays and working days helper and toolkit.'
+NAME = "workalendar"
+DESCRIPTION = "Worldwide holidays and working days helper and toolkit."
 REQUIREMENTS = [
-    'python-dateutil',
-    'lunardate',
-    'pytz',
-    'pyCalverter',
-    'setuptools>=1.0',
+    "python-dateutil",
+    "lunardate",
+    "pytz",
+    "pyCalverter",
+    "pyluach",
+    "setuptools>=1.0",
 ]
-version = '2.7.0.dev0'
+version = "2.7.0.dev0"
 __VERSION__ = version
 
 if PY2:
-    REQUIREMENTS.append('pyephem')
+    REQUIREMENTS.append("pyephem")
 else:
-    REQUIREMENTS.append('ephem')
+    REQUIREMENTS.append("ephem")
 
 params = dict(
     name=NAME,
     description=DESCRIPTION,
     packages=find_packages(),
     version=__VERSION__,
-    long_description=read_relative_file('README.rst'),
-    author='Bruno Bord',
-    author_email='bruno.bord@people-doc.com',
-    url='https://github.com/peopledoc/workalendar',
-    license='MIT License',
+    long_description=read_relative_file("README.rst"),
+    author="Bruno Bord",
+    author_email="bruno.bord@people-doc.com",
+    url="https://github.com/peopledoc/workalendar",
+    license="MIT License",
     include_package_data=True,
     install_requires=REQUIREMENTS,
     zip_safe=False,
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
     ],
 )
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     setup(**params)

--- a/workalendar/asia/__init__.py
+++ b/workalendar/asia/__init__.py
@@ -6,14 +6,16 @@ from .qatar import Qatar
 from .singapore import Singapore
 from .south_korea import SouthKorea
 from .taiwan import Taiwan
+from .israel import Israel
 
 
 __all__ = (
-    'HongKong',
-    'Japan',
-    'Malaysia',
-    'Qatar',
-    'Singapore',
-    'SouthKorea',
-    'Taiwan',
+    "HongKong",
+    "Japan",
+    "Malaysia",
+    "Qatar",
+    "Singapore",
+    "SouthKorea",
+    "Taiwan",
+    "Israel",
 )

--- a/workalendar/asia/israel.py
+++ b/workalendar/asia/israel.py
@@ -1,0 +1,84 @@
+from datetime import date, timedelta
+
+from pyluach.dates import GregorianDate, HebrewDate
+
+from workalendar.core import Calendar, FRI, SAT
+from workalendar.registry import iso_register
+
+
+@iso_register("IL")
+class Israel(Calendar):
+    "Israel"
+
+    WEEKEND_DAYS = (SAT, FRI)
+
+    def get_variable_days(self, year):
+        days = super(Israel, self).get_variable_days(year)
+
+        delta = timedelta(days=1)
+        current_date = date(year, 1, 1)
+
+        while current_date.year == year:
+            hebrew_date = GregorianDate(
+                year=current_date.year,
+                month=current_date.month,
+                day=current_date.day,
+            ).to_heb()
+
+            jewish_year = hebrew_date.year
+            month = hebrew_date.month
+            day = hebrew_date.day
+
+            if month == 7:
+                if day in {1, 2, 3}:
+                    days.append((current_date, "Rosh Hashana"))
+                elif day == 10:
+                    days.append((current_date, "Yom Kippur"))
+                elif day in range(15, 22):
+                    days.append((current_date, "Sukkot"))
+                elif day == 22:
+                    days.append((current_date, "Shmini Atzeres"))
+            elif month == 12:
+                leap = HebrewDate._is_leap(jewish_year)
+                if day == 14:
+                    days.append((current_date, "Purim"))
+                if day == 15 and not leap:
+                    days.append((current_date, "Purim"))
+            elif month == 13:
+                if day == 14:
+                    days.append((current_date, "Purim"))
+                elif day == 15:
+                    days.append((current_date, "Shushan Purim"))
+            elif month == 1 and day in {15, 21}:
+                days.append((current_date, "Pesach"))
+            elif month == 2:
+                if day == 5:
+                    if hebrew_date.weekday() == 6:
+                        days.append(
+                            (
+                                HebrewDate(jewish_year, month, 4).to_pydate(),
+                                "Independence Day",
+                            )
+                        )
+                    elif hebrew_date.weekday() == 7:
+                        days.append(
+                            (
+                                HebrewDate(jewish_year, month, 3).to_pydate(),
+                                "Independence Day",
+                            )
+                        )
+                    elif hebrew_date.weekday() == 2:
+                        days.append(
+                            (
+                                HebrewDate(jewish_year, month, 6).to_pydate(),
+                                "Independence Day",
+                            )
+                        )
+                    else:
+                        days.append((current_date, "Independence Day"))
+            elif month == 3 and day == 6:
+                days.append((current_date, "Shavout"))
+
+            current_date += delta
+
+        return days

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -1,8 +1,16 @@
 from datetime import date
 from workalendar.tests import GenericCalendarTest
 
-from workalendar.asia import HongKong, Japan, Qatar, Singapore
-from workalendar.asia import SouthKorea, Taiwan, Malaysia
+from workalendar.asia import (
+    HongKong,
+    Japan,
+    Qatar,
+    Singapore,
+    SouthKorea,
+    Taiwan,
+    Malaysia,
+    Israel,
+)
 
 
 class HongKongTest(GenericCalendarTest):
@@ -14,81 +22,81 @@ class HongKongTest(GenericCalendarTest):
             on a Sunday, so didn't roll, and Ching Ming was on the same day
             as Easter Monday """
         holidays = self.cal.holidays_set(2010)
-        self.assertIn(date(2010, 1, 1), holidays)    # New Year
-        self.assertIn(date(2010, 2, 13), holidays)   # Chinese new year (shift)
-        self.assertIn(date(2010, 2, 15), holidays)   # Chinese new year
-        self.assertIn(date(2010, 2, 16), holidays)   # Chinese new year
+        self.assertIn(date(2010, 1, 1), holidays)  # New Year
+        self.assertIn(date(2010, 2, 13), holidays)  # Chinese new year (shift)
+        self.assertIn(date(2010, 2, 15), holidays)  # Chinese new year
+        self.assertIn(date(2010, 2, 16), holidays)  # Chinese new year
         self.assertNotIn(date(2010, 2, 17), holidays)  # Not Chinese new year
-        self.assertIn(date(2010, 4, 2), holidays)    # Good Friday
-        self.assertIn(date(2010, 4, 3), holidays)    # Day after Good Friday
-        self.assertIn(date(2010, 4, 5), holidays)    # Easter Monday
-        self.assertIn(date(2010, 4, 6), holidays)    # Ching Ming (shifted)
-        self.assertIn(date(2010, 5, 1), holidays)    # Labour Day
-        self.assertIn(date(2010, 5, 21), holidays)   # Buddha's Birthday
-        self.assertIn(date(2010, 6, 16), holidays)   # Tuen Ng Festival
-        self.assertIn(date(2010, 7, 1), holidays)    # HK SAR Establishment Day
-        self.assertIn(date(2010, 9, 23), holidays)   # Day after Mid-Autumn
-        self.assertIn(date(2010, 10, 1), holidays)   # National Day
+        self.assertIn(date(2010, 4, 2), holidays)  # Good Friday
+        self.assertIn(date(2010, 4, 3), holidays)  # Day after Good Friday
+        self.assertIn(date(2010, 4, 5), holidays)  # Easter Monday
+        self.assertIn(date(2010, 4, 6), holidays)  # Ching Ming (shifted)
+        self.assertIn(date(2010, 5, 1), holidays)  # Labour Day
+        self.assertIn(date(2010, 5, 21), holidays)  # Buddha's Birthday
+        self.assertIn(date(2010, 6, 16), holidays)  # Tuen Ng Festival
+        self.assertIn(date(2010, 7, 1), holidays)  # HK SAR Establishment Day
+        self.assertIn(date(2010, 9, 23), holidays)  # Day after Mid-Autumn
+        self.assertIn(date(2010, 10, 1), holidays)  # National Day
         self.assertIn(date(2010, 10, 16), holidays)  # Chung Yeung Festival
         self.assertIn(date(2010, 12, 25), holidays)  # Christmas Day
         self.assertIn(date(2010, 12, 27), holidays)  # Boxing Day (shifted)
 
     def test_year_2013(self):
         holidays = self.cal.holidays_set(2013)
-        self.assertIn(date(2013, 1, 1), holidays)    # New Year
-        self.assertIn(date(2013, 2, 11), holidays)   # Chinese new year
-        self.assertIn(date(2013, 2, 12), holidays)   # Chinese new year
-        self.assertIn(date(2013, 2, 13), holidays)   # Chinese new year
-        self.assertIn(date(2013, 3, 29), holidays)   # Good Friday
-        self.assertIn(date(2013, 3, 30), holidays)   # Day after Good Friday
-        self.assertIn(date(2013, 4, 1), holidays)    # Easter Monday
-        self.assertIn(date(2013, 4, 4), holidays)    # Ching Ming
-        self.assertIn(date(2013, 5, 1), holidays)    # Labour Day
-        self.assertIn(date(2013, 5, 17), holidays)   # Buddha's Birthday
-        self.assertIn(date(2013, 6, 12), holidays)   # Tuen Ng Festival
-        self.assertIn(date(2013, 7, 1), holidays)    # HK SAR Establishment Day
-        self.assertIn(date(2013, 9, 20), holidays)   # Day after Mid-Autumn
-        self.assertIn(date(2013, 10, 1), holidays)   # National Day
+        self.assertIn(date(2013, 1, 1), holidays)  # New Year
+        self.assertIn(date(2013, 2, 11), holidays)  # Chinese new year
+        self.assertIn(date(2013, 2, 12), holidays)  # Chinese new year
+        self.assertIn(date(2013, 2, 13), holidays)  # Chinese new year
+        self.assertIn(date(2013, 3, 29), holidays)  # Good Friday
+        self.assertIn(date(2013, 3, 30), holidays)  # Day after Good Friday
+        self.assertIn(date(2013, 4, 1), holidays)  # Easter Monday
+        self.assertIn(date(2013, 4, 4), holidays)  # Ching Ming
+        self.assertIn(date(2013, 5, 1), holidays)  # Labour Day
+        self.assertIn(date(2013, 5, 17), holidays)  # Buddha's Birthday
+        self.assertIn(date(2013, 6, 12), holidays)  # Tuen Ng Festival
+        self.assertIn(date(2013, 7, 1), holidays)  # HK SAR Establishment Day
+        self.assertIn(date(2013, 9, 20), holidays)  # Day after Mid-Autumn
+        self.assertIn(date(2013, 10, 1), holidays)  # National Day
         self.assertIn(date(2013, 10, 14), holidays)  # Chung Yeung Festival
         self.assertIn(date(2013, 12, 25), holidays)  # Christmas Day
         self.assertIn(date(2013, 12, 26), holidays)  # Boxing Day
 
     def test_year_2016(self):
         holidays = self.cal.holidays_set(2016)
-        self.assertIn(date(2016, 1, 1), holidays)    # New Year
-        self.assertIn(date(2016, 2, 8), holidays)    # Chinese new year
-        self.assertIn(date(2016, 2, 9), holidays)    # Chinese new year
-        self.assertIn(date(2016, 2, 10), holidays)   # Chinese new year
-        self.assertIn(date(2016, 3, 25), holidays)   # Good Friday
-        self.assertIn(date(2016, 3, 26), holidays)   # Day after Good Friday
-        self.assertIn(date(2016, 3, 28), holidays)   # Easter Monday
-        self.assertIn(date(2016, 4, 4), holidays)    # Ching Ming
-        self.assertIn(date(2016, 5, 2), holidays)    # Labour Day (shifted)
-        self.assertIn(date(2016, 5, 14), holidays)   # Buddha's Birthday
-        self.assertIn(date(2016, 6, 9), holidays)    # Tuen Ng Festival
-        self.assertIn(date(2016, 7, 1), holidays)    # HK SAR Establishment Day
-        self.assertIn(date(2016, 9, 16), holidays)   # Day after Mid-Autumn
-        self.assertIn(date(2016, 10, 1), holidays)   # National Day
+        self.assertIn(date(2016, 1, 1), holidays)  # New Year
+        self.assertIn(date(2016, 2, 8), holidays)  # Chinese new year
+        self.assertIn(date(2016, 2, 9), holidays)  # Chinese new year
+        self.assertIn(date(2016, 2, 10), holidays)  # Chinese new year
+        self.assertIn(date(2016, 3, 25), holidays)  # Good Friday
+        self.assertIn(date(2016, 3, 26), holidays)  # Day after Good Friday
+        self.assertIn(date(2016, 3, 28), holidays)  # Easter Monday
+        self.assertIn(date(2016, 4, 4), holidays)  # Ching Ming
+        self.assertIn(date(2016, 5, 2), holidays)  # Labour Day (shifted)
+        self.assertIn(date(2016, 5, 14), holidays)  # Buddha's Birthday
+        self.assertIn(date(2016, 6, 9), holidays)  # Tuen Ng Festival
+        self.assertIn(date(2016, 7, 1), holidays)  # HK SAR Establishment Day
+        self.assertIn(date(2016, 9, 16), holidays)  # Day after Mid-Autumn
+        self.assertIn(date(2016, 10, 1), holidays)  # National Day
         self.assertIn(date(2016, 10, 10), holidays)  # Chung Yeung Festival
         self.assertIn(date(2016, 12, 26), holidays)  # Christmas Day (shifted)
         self.assertIn(date(2016, 12, 27), holidays)  # Boxing Day (shifted)
 
     def test_year_2017(self):
         holidays = self.cal.holidays_set(2017)
-        self.assertIn(date(2017, 1, 2), holidays)    # New Year (shifted)
-        self.assertIn(date(2017, 1, 28), holidays)   # Chinese new year
-        self.assertIn(date(2017, 1, 30), holidays)   # Chinese new year
-        self.assertIn(date(2017, 1, 31), holidays)   # Chinese new year
-        self.assertIn(date(2017, 4, 4), holidays)    # Ching Ming
-        self.assertIn(date(2017, 4, 14), holidays)   # Good Friday
-        self.assertIn(date(2017, 4, 15), holidays)   # Day after Good Friday
-        self.assertIn(date(2017, 4, 17), holidays)   # Easter Monday
-        self.assertIn(date(2017, 5, 1), holidays)    # Labour Day
-        self.assertIn(date(2017, 5, 3), holidays)    # Buddha's Birthday
-        self.assertIn(date(2017, 5, 30), holidays)   # Tuen Ng Festival
-        self.assertIn(date(2017, 7, 1), holidays)    # HK SAR Establishment Day
-        self.assertIn(date(2017, 10, 2), holidays)   # National Day (shifted)
-        self.assertIn(date(2017, 10, 5), holidays)   # Day after Mid-Autumn
+        self.assertIn(date(2017, 1, 2), holidays)  # New Year (shifted)
+        self.assertIn(date(2017, 1, 28), holidays)  # Chinese new year
+        self.assertIn(date(2017, 1, 30), holidays)  # Chinese new year
+        self.assertIn(date(2017, 1, 31), holidays)  # Chinese new year
+        self.assertIn(date(2017, 4, 4), holidays)  # Ching Ming
+        self.assertIn(date(2017, 4, 14), holidays)  # Good Friday
+        self.assertIn(date(2017, 4, 15), holidays)  # Day after Good Friday
+        self.assertIn(date(2017, 4, 17), holidays)  # Easter Monday
+        self.assertIn(date(2017, 5, 1), holidays)  # Labour Day
+        self.assertIn(date(2017, 5, 3), holidays)  # Buddha's Birthday
+        self.assertIn(date(2017, 5, 30), holidays)  # Tuen Ng Festival
+        self.assertIn(date(2017, 7, 1), holidays)  # HK SAR Establishment Day
+        self.assertIn(date(2017, 10, 2), holidays)  # National Day (shifted)
+        self.assertIn(date(2017, 10, 5), holidays)  # Day after Mid-Autumn
         self.assertIn(date(2017, 10, 28), holidays)  # Chung Yeung Festival
         self.assertIn(date(2017, 12, 25), holidays)  # Christmas Day
         self.assertIn(date(2017, 12, 26), holidays)  # Boxing Day
@@ -117,35 +125,35 @@ class JapanTest(GenericCalendarTest):
 
     def test_year_2013(self):
         holidays = self.cal.holidays_set(2013)
-        self.assertIn(date(2013, 1, 1), holidays)    # new year
-        self.assertIn(date(2013, 2, 11), holidays)   # Foundation Day
-        self.assertIn(date(2013, 3, 20), holidays)   # Vernal Equinox Day
-        self.assertIn(date(2013, 4, 29), holidays)   # Showa Day
+        self.assertIn(date(2013, 1, 1), holidays)  # new year
+        self.assertIn(date(2013, 2, 11), holidays)  # Foundation Day
+        self.assertIn(date(2013, 3, 20), holidays)  # Vernal Equinox Day
+        self.assertIn(date(2013, 4, 29), holidays)  # Showa Day
         self.assertIn(date(2013, 5, 3), holidays)  # Constitution Memorial Day
-        self.assertIn(date(2013, 5, 4), holidays)    # Greenery Day
-        self.assertIn(date(2013, 5, 5), holidays)    # Children's Day
-        self.assertIn(date(2013, 9, 23), holidays)   # Autumnal Equinox Day
-        self.assertIn(date(2013, 11, 3), holidays)   # Culture Day
+        self.assertIn(date(2013, 5, 4), holidays)  # Greenery Day
+        self.assertIn(date(2013, 5, 5), holidays)  # Children's Day
+        self.assertIn(date(2013, 9, 23), holidays)  # Autumnal Equinox Day
+        self.assertIn(date(2013, 11, 3), holidays)  # Culture Day
         self.assertIn(date(2013, 11, 23), holidays)  # Labour Thanksgiving Day
         self.assertIn(date(2013, 12, 23), holidays)  # The Emperor's Birthday
 
         # Variable days
-        self.assertIn(date(2013, 1, 14), holidays)   # Coming of Age Day
-        self.assertIn(date(2013, 7, 15), holidays)   # Marine Day
-        self.assertIn(date(2013, 9, 16), holidays)   # Respect-for-the-Aged Day
+        self.assertIn(date(2013, 1, 14), holidays)  # Coming of Age Day
+        self.assertIn(date(2013, 7, 15), holidays)  # Marine Day
+        self.assertIn(date(2013, 9, 16), holidays)  # Respect-for-the-Aged Day
         self.assertIn(date(2013, 10, 14), holidays)  # Health and Sports Day
 
     def test_year_2016(self):
         # Before 2016, no Mountain Day
         holidays = self.cal.holidays_set(2014)
-        self.assertNotIn(date(2014, 8, 11), holidays)   # Mountain Day
+        self.assertNotIn(date(2014, 8, 11), holidays)  # Mountain Day
         holidays = self.cal.holidays_set(2015)
-        self.assertNotIn(date(2015, 8, 11), holidays)   # Mountain Day
+        self.assertNotIn(date(2015, 8, 11), holidays)  # Mountain Day
         # After 2016, yes
         holidays = self.cal.holidays_set(2016)
-        self.assertIn(date(2016, 8, 11), holidays)   # Mountain Day
+        self.assertIn(date(2016, 8, 11), holidays)  # Mountain Day
         holidays = self.cal.holidays_set(2017)
-        self.assertIn(date(2017, 8, 11), holidays)   # Mountain Day
+        self.assertIn(date(2017, 8, 11), holidays)  # Mountain Day
 
 
 class MalaysiaTest(GenericCalendarTest):
@@ -153,33 +161,33 @@ class MalaysiaTest(GenericCalendarTest):
 
     def test_year_2013(self):
         holidays = self.cal.holidays_set(2013)
-        self.assertIn(date(2013, 1, 1), holidays)    # New Year's Day
-        self.assertIn(date(2013, 1, 28), holidays)   # Thaipusam
-        self.assertIn(date(2013, 2, 1), holidays)    # Federal Territory Day
-        self.assertIn(date(2013, 2, 11), holidays)   # 2nd day of Lunar NY
-        self.assertIn(date(2013, 2, 12), holidays)   # 1st day (Sun lieu)
-        self.assertIn(date(2013, 5, 1), holidays)    # Workers' Day
-        self.assertIn(date(2013, 5, 24), holidays)   # Vesak Day
-        self.assertIn(date(2013, 8, 8), holidays)    # 1st day eid-al-fitr
-        self.assertIn(date(2013, 8, 9), holidays)    # 2nd day eid-al-fitr
-        self.assertIn(date(2013, 8, 31), holidays)   # National Day
-        self.assertIn(date(2013, 9, 16), holidays)   # Malaysia Day
+        self.assertIn(date(2013, 1, 1), holidays)  # New Year's Day
+        self.assertIn(date(2013, 1, 28), holidays)  # Thaipusam
+        self.assertIn(date(2013, 2, 1), holidays)  # Federal Territory Day
+        self.assertIn(date(2013, 2, 11), holidays)  # 2nd day of Lunar NY
+        self.assertIn(date(2013, 2, 12), holidays)  # 1st day (Sun lieu)
+        self.assertIn(date(2013, 5, 1), holidays)  # Workers' Day
+        self.assertIn(date(2013, 5, 24), holidays)  # Vesak Day
+        self.assertIn(date(2013, 8, 8), holidays)  # 1st day eid-al-fitr
+        self.assertIn(date(2013, 8, 9), holidays)  # 2nd day eid-al-fitr
+        self.assertIn(date(2013, 8, 31), holidays)  # National Day
+        self.assertIn(date(2013, 9, 16), holidays)  # Malaysia Day
         self.assertIn(date(2013, 10, 15), holidays)  # Hari Raya Haji
-        self.assertIn(date(2013, 11, 2), holidays)   # Deepavali
-        self.assertIn(date(2013, 11, 5), holidays)   # Islamic New Year
+        self.assertIn(date(2013, 11, 2), holidays)  # Deepavali
+        self.assertIn(date(2013, 11, 5), holidays)  # Islamic New Year
         self.assertIn(date(2013, 12, 25), holidays)  # Xmas
 
     def test_year_2012(self):
         holidays = self.cal.holidays_set(2012)
-        self.assertIn(date(2012, 1, 1), holidays)    # New Year's Day
-        self.assertIn(date(2012, 1, 24), holidays)   # Federal Territory Day
-        self.assertIn(date(2012, 2, 1), holidays)    # 2nd day of Lunar NY
-        self.assertIn(date(2012, 5, 1), holidays)    # 1st day (Sun lieu)
-        self.assertIn(date(2012, 5, 5), holidays)    # Workers' Day
-        self.assertIn(date(2012, 8, 19), holidays)   # 1st day eid-al-fitr
-        self.assertIn(date(2012, 8, 20), holidays)   # 2nd day eid-al-fitr
-        self.assertIn(date(2012, 8, 31), holidays)   # National Day
-        self.assertIn(date(2012, 9, 16), holidays)   # Malaysia Day
+        self.assertIn(date(2012, 1, 1), holidays)  # New Year's Day
+        self.assertIn(date(2012, 1, 24), holidays)  # Federal Territory Day
+        self.assertIn(date(2012, 2, 1), holidays)  # 2nd day of Lunar NY
+        self.assertIn(date(2012, 5, 1), holidays)  # 1st day (Sun lieu)
+        self.assertIn(date(2012, 5, 5), holidays)  # Workers' Day
+        self.assertIn(date(2012, 8, 19), holidays)  # 1st day eid-al-fitr
+        self.assertIn(date(2012, 8, 20), holidays)  # 2nd day eid-al-fitr
+        self.assertIn(date(2012, 8, 31), holidays)  # National Day
+        self.assertIn(date(2012, 9, 16), holidays)  # Malaysia Day
         self.assertIn(date(2012, 10, 26), holidays)  # Hari Raya Haji
         self.assertIn(date(2012, 11, 13), holidays)  # Islamic New Year
         self.assertIn(date(2012, 11, 15), holidays)  # Deepavali
@@ -270,13 +278,13 @@ class SouthKoreaTest(GenericCalendarTest):
 
     def test_year_2013(self):
         holidays = self.cal.holidays_set(2013)
-        self.assertIn(date(2013, 1, 1), holidays)    # new year
-        self.assertIn(date(2013, 3, 1), holidays)    # Independence day
-        self.assertIn(date(2013, 5, 5), holidays)    # children's day
-        self.assertIn(date(2013, 6, 6), holidays)    # Memorial day
-        self.assertIn(date(2013, 8, 15), holidays)   # Liberation day
-        self.assertIn(date(2013, 10, 3), holidays)   # National Foundation Day
-        self.assertIn(date(2013, 10, 9), holidays)   # Hangul Day
+        self.assertIn(date(2013, 1, 1), holidays)  # new year
+        self.assertIn(date(2013, 3, 1), holidays)  # Independence day
+        self.assertIn(date(2013, 5, 5), holidays)  # children's day
+        self.assertIn(date(2013, 6, 6), holidays)  # Memorial day
+        self.assertIn(date(2013, 8, 15), holidays)  # Liberation day
+        self.assertIn(date(2013, 10, 3), holidays)  # National Foundation Day
+        self.assertIn(date(2013, 10, 9), holidays)  # Hangul Day
         self.assertIn(date(2013, 12, 25), holidays)  # Christmas
 
         # Variable days
@@ -295,15 +303,15 @@ class TaiwanTest(GenericCalendarTest):
 
     def test_year_2013(self):
         holidays = self.cal.holidays_set(2013)
-        self.assertIn(date(2013, 1, 1), holidays)    # New Year
-        self.assertIn(date(2013, 2, 9), holidays)    # Chinese new year's eve
-        self.assertIn(date(2013, 2, 10), holidays)   # Chinese new year
-        self.assertIn(date(2013, 2, 11), holidays)   # Spring Festival
-        self.assertIn(date(2013, 2, 12), holidays)   # Spring Festival
-        self.assertIn(date(2013, 2, 28), holidays)   # 228 Peace Memorial Day
-        self.assertIn(date(2013, 4, 4), holidays)    # Children's Day
-        self.assertIn(date(2013, 6, 12), holidays)   # Dragon Boat Festival
-        self.assertIn(date(2013, 9, 19), holidays)   # Mid-Autumn Festival
+        self.assertIn(date(2013, 1, 1), holidays)  # New Year
+        self.assertIn(date(2013, 2, 9), holidays)  # Chinese new year's eve
+        self.assertIn(date(2013, 2, 10), holidays)  # Chinese new year
+        self.assertIn(date(2013, 2, 11), holidays)  # Spring Festival
+        self.assertIn(date(2013, 2, 12), holidays)  # Spring Festival
+        self.assertIn(date(2013, 2, 28), holidays)  # 228 Peace Memorial Day
+        self.assertIn(date(2013, 4, 4), holidays)  # Children's Day
+        self.assertIn(date(2013, 6, 12), holidays)  # Dragon Boat Festival
+        self.assertIn(date(2013, 9, 19), holidays)  # Mid-Autumn Festival
         self.assertIn(date(2013, 10, 10), holidays)  # National Day
 
     def test_qingming_festival(self):
@@ -318,3 +326,48 @@ class TaiwanTest(GenericCalendarTest):
         self.assertIn(date(2012, 4, 4), self.cal.holidays_set(2012))
         self.assertIn(date(2013, 4, 4), self.cal.holidays_set(2013))
         self.assertIn(date(2014, 4, 4), self.cal.holidays_set(2014))
+
+
+class IsraelTest(GenericCalendarTest):
+
+    cal_class = Israel
+
+    def test_holeidays_2017(self):
+        holidays = self.cal.holidays_set(2017)
+
+        self.assertIn(date(2017, 4, 11), holidays)  # Passover (Pesach)
+        self.assertIn(date(2017, 4, 17), holidays)  # Passover (Pesach)
+        self.assertIn(
+            date(2017, 5, 2), holidays
+        )  # Independence Day (Yom Ha-Atzmaut), was early in 2017
+        self.assertIn(date(2017, 5, 31), holidays)  # Shavuot
+        self.assertIn(
+            date(2017, 9, 21), holidays
+        )  # Jewish New Year (Rosh Ha-Shana)
+        self.assertIn(
+            date(2017, 9, 22), holidays
+        )  # Jewish New Year (Rosh Ha-Shana)
+        self.assertIn(
+            date(2017, 9, 30), holidays
+        )  # Yom Kippur (already a Saturday - Shabbat, weekend day)
+        self.assertIn(date(2017, 10, 5), holidays)  # Sukkot
+        self.assertIn(date(2017, 10, 12), holidays)  # Sukkot
+
+    def test_holidays_2018(self):
+        holidays = self.cal.holidays_set(2018)
+
+        self.assertIn(date(2018, 3, 31), holidays)  # Passover (Pesach)
+        self.assertIn(date(2018, 4, 6), holidays)  # Passover (Pesach)
+        self.assertIn(
+            date(2018, 4, 19), holidays
+        )  # Independence Day (Yom Ha-Atzmaut), was delayed in 2018
+        self.assertIn(date(2018, 5, 20), holidays)  # Shavuot
+        self.assertIn(
+            date(2018, 9, 10), holidays
+        )  # Jewish New Year (Rosh Ha-Shana)
+        self.assertIn(
+            date(2018, 9, 11), holidays
+        )  # Jewish New Year (Rosh Ha-Shana)
+        self.assertIn(date(2018, 9, 19), holidays)  # Yom Kippur
+        self.assertIn(date(2018, 9, 24), holidays)  # Sukkot
+        self.assertIn(date(2018, 10, 1), holidays)  # Sukkot


### PR DESCRIPTION
Holidays which are not included:

- There are holidays which are taken as day off by large portions of the
population but are not considered official holidays, e.g. Chanuka.
- There are a lot of Jewish holidays which are not public holidays
- There are Muslim holidays which are considered days off for the Muslim
population
- Holidays which are optional paid leave e.g. Jerusalem Day
- School holidays

Thanks for @tsehori for the tests

refs #278 
