### PR TITLE
Fix ISO 3166-1 code for Slovenia

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Fixed ISO 3166-1 code for the `Slovenia` calendar.
 
 ## v3.1.0 (2018-10-25)
 

--- a/workalendar/europe/slovenia.py
+++ b/workalendar/europe/slovenia.py
@@ -5,7 +5,7 @@ from workalendar.core import WesternCalendar, ChristianMixin
 from workalendar.registry import iso_register
 
 
-@iso_register('SL')
+@iso_register('SI')
 class Slovenia(WesternCalendar, ChristianMixin):
     'Slovenia'
 


### PR DESCRIPTION
Slovenia calendar currently has ISO 3166-1 code `SL`, which is actually Sierra Leone. It should be `SI`. Source: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#SI

- [ ] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes.
