### PR TITLE
Remove dependency to PyEphem.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Removed dependency to `PyEphem`. This package was the "Python2-compatible" library to deal with the xephem system library. Now it's obsolete, so you don't need this dual-dependency handling, because `ephem` is compatible with Python 2 & Python 3 (#296).
 
 ## v3.1.1 (2018-11-17)
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ def read_relative_file(filename):
 NAME = 'workalendar'
 DESCRIPTION = 'Worldwide holidays and working days helper and toolkit.'
 REQUIREMENTS = [
+    'ephem',
     'python-dateutil',
     'lunardate',
     'pytz',
@@ -27,11 +28,6 @@ REQUIREMENTS = [
 ]
 version = '3.2.0.dev0'
 __VERSION__ = version
-
-if PY2:
-    REQUIREMENTS.append('pyephem')
-else:
-    REQUIREMENTS.append('ephem')
 
 params = dict(
     name=NAME,


### PR DESCRIPTION
The `ephem` library is Python 2 & 3 compatible.
closes #296

- [x] Changelog amended with a mention describing your changes.
