### PR TITLE
Securing the core function arguments to valid types

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - Removed dependency to `PyEphem`. This package was the "Python2-compatible" library to deal with the xephem system library. Now it's obsolete, so you don't need this dual-dependency handling, because `ephem` is compatible with Python 2 & Python 3 (#296).
+- Raise an exception when trying to use unsupported date/datetime types (#294).
 
 ## v3.1.1 (2018-11-17)
 

--- a/docs/basic.md
+++ b/docs/basic.md
@@ -81,10 +81,13 @@ Let's say you want to know how many working days there are between April 2nd and
 50
 ```
 
+## Standard date(time) types only, please!
 
-## Don't worry about the date types!
+For your convenience, we allow both `datetime.date` and `datetime.datetime` types (and their subclasses) when using the core functions.
 
-For your convenience, we allow both `datetime.date` and `datetime.datetime` types when using the core functions. Example:
+**WARNING**: We'll only allow "dates" types coming from the Python standard library. If you're manipulating types from external library. Trying to pass a non-standard argument will result in raising a ``UnsupportedDateType`` error.
+
+Example:
 
 ```python
 >>> from datetime import date, datetime

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py27,flake8,py34,py35,py36,py37,py36-cov,py27-cov
 
 [testenv]
 deps =
+    pandas
     pytest
     cov: pytest-cov
 

--- a/workalendar/exceptions.py
+++ b/workalendar/exceptions.py
@@ -7,3 +7,9 @@ class CalendarError(Exception):
     """
     Base Calendar Error
     """
+
+
+class UnsupportedDateType(CalendarError):
+    """
+    Raised when trying to use an unsupported date/datetime type.
+    """

--- a/workalendar/tests/test_core.py
+++ b/workalendar/tests/test_core.py
@@ -2,11 +2,14 @@ from datetime import date
 from datetime import datetime
 from unittest import TestCase
 
+import pandas
+
 from workalendar.tests import GenericCalendarTest
 from workalendar.core import MON, TUE, THU, FRI, WED, SAT, SUN
 from workalendar.core import Calendar, LunarCalendar, WesternCalendar
 from workalendar.core import IslamicMixin, JalaliMixin, ChristianMixin
 from workalendar.core import EphemMixin
+from workalendar.exceptions import UnsupportedDateType
 
 
 class CalendarTest(GenericCalendarTest):
@@ -211,77 +214,11 @@ class MockCalendarTest(GenericCalendarTest):
         # test is_holiday
         self.assertTrue(self.cal.is_holiday(christmas))
 
-    def test_add_working_days_datetime(self):
-        # datetime inside, date outside
-        self.assertEquals(
-            self.cal.add_working_days(
-                datetime(self.year, 12, 20, 12, 34, 56), 0),
-            date(self.year, 12, 20)
-        )
-        self.assertEquals(
-            self.cal.add_working_days(
-                datetime(self.year, 12, 20, 12, 34, 56), 1),
-            date(self.year, 12, 21)
-        )
-
-        # Use the `keep_datetime` option
-        self.assertEquals(
-            self.cal.add_working_days(
-                datetime(self.year, 12, 20, 12, 34, 56),
-                0, keep_datetime=True),
-            datetime(self.year, 12, 20, 12, 34, 56)
-        )
-        self.assertEquals(
-            self.cal.add_working_days(
-                datetime(self.year, 12, 20, 12, 34, 56),
-                1, keep_datetime=True),
-            datetime(self.year, 12, 21, 12, 34, 56)
-        )
-
-    def test_sub_working_days_datetime(self):
-        # datetime inside, date outside
-        self.assertEquals(
-            self.cal.sub_working_days(
-                datetime(self.year, 12, 20, 12, 34, 56), 0),
-            date(self.year, 12, 20)
-        )
-        self.assertEquals(
-            self.cal.sub_working_days(
-                datetime(self.year, 12, 20, 12, 34, 56), 1),
-            date(self.year, 12, 19)
-        )
-
-        # Use the `keep_datetime` option
-        self.assertEquals(
-            self.cal.sub_working_days(
-                datetime(self.year, 12, 20, 12, 34, 56),
-                0, keep_datetime=True),
-            datetime(self.year, 12, 20, 12, 34, 56)
-        )
-        self.assertEquals(
-            self.cal.sub_working_days(
-                datetime(self.year, 12, 20, 12, 34, 56),
-                1, keep_datetime=True),
-            datetime(self.year, 12, 19, 12, 34, 56)
-        )
-
-    def test_datetime(self):
-        self.assertFalse(
-            self.cal.is_working_day(datetime(2014, 1, 1)))
-        self.assertTrue(
-            self.cal.is_holiday(datetime(2014, 1, 1)))
-
     def test_get_holiday_label(self):
         self.assertEqual(
             self.cal.get_holiday_label(date(2014, 1, 1)), 'New year')
         self.assertIsNone(
             self.cal.get_holiday_label(date(2014, 1, 2)))
-
-    def test_get_holiday_label_with_datetime(self):
-        self.assertEqual(
-            self.cal.get_holiday_label(datetime(2014, 1, 1)), 'New year')
-        self.assertIsNone(
-            self.cal.get_holiday_label(datetime(2014, 1, 2)))
 
     def test_add_working_days_backwards(self):
         day = date(self.year, 1, 3)
@@ -577,3 +514,242 @@ class CalendarClassName(TestCase):
         self.assertEqual(
             MultipleLineEmptyFirstDocstring.name, "Multiple line empty first"
         )
+
+
+class TestAcceptableDateTypes(GenericCalendarTest):
+    """
+    Test cases about accepted date and datetime types.
+    """
+    cal_class = MockCalendar
+    unsupported = ('hello', 1)
+
+    def test_unsupported_type_is_working_day(self):
+        for arg in self.unsupported:
+            with self.assertRaises(UnsupportedDateType):
+                self.cal.is_working_day(arg)
+
+        # Extra holidays optional argument
+        for arg in self.unsupported:
+            with self.assertRaises(UnsupportedDateType):
+                self.cal.is_working_day(
+                    date(2018, 1, 1),
+                    extra_holidays=[arg]
+                )
+        # Extra working days optional argument
+        for arg in self.unsupported:
+            with self.assertRaises(UnsupportedDateType):
+                self.cal.is_working_day(
+                    date(2018, 1, 1),
+                    extra_working_days=[arg]
+                )
+
+    def test_unsupported_type_is_holiday(self):
+        for arg in self.unsupported:
+            with self.assertRaises(UnsupportedDateType):
+                self.cal.is_holiday(arg)
+
+        # Extra holidays optional argument
+        for arg in self.unsupported:
+            with self.assertRaises(UnsupportedDateType):
+                self.cal.is_holiday(
+                    date(2018, 1, 1),
+                    extra_holidays=[arg]
+                )
+
+    def test_unsupported_type_holiday_label(self):
+        for arg in self.unsupported:
+            with self.assertRaises(UnsupportedDateType):
+                self.cal.get_holiday_label(arg)
+
+    def test_unsupported_type_add_sub_working_days(self):
+        for arg in self.unsupported:
+            with self.assertRaises(UnsupportedDateType):
+                self.cal.add_working_days(arg, 1)
+
+        for arg in self.unsupported:
+            with self.assertRaises(UnsupportedDateType):
+                self.cal.sub_working_days(arg, 1)
+
+        # Extra holidays optional argument
+        for arg in self.unsupported:
+            with self.assertRaises(UnsupportedDateType):
+                self.cal.add_working_days(
+                    date(2018, 1, 1), 1,
+                    extra_holidays=[arg]
+                )
+        # Extra working days optional argument
+        for arg in self.unsupported:
+            with self.assertRaises(UnsupportedDateType):
+                self.cal.add_working_days(
+                    date(2018, 1, 1), 1,
+                    extra_working_days=[arg]
+                )
+        # NOTE: no need to test "sub", they're calling each other.
+
+    def test_unsupported_type_find_following_working_day(self):
+        for arg in self.unsupported:
+            with self.assertRaises(UnsupportedDateType):
+                self.cal.find_following_working_day(arg)
+
+    def test_unsupported_type_get_nth_weekday_in_month(self):
+        for arg in self.unsupported:
+            with self.assertRaises(UnsupportedDateType):
+                self.cal.get_nth_weekday_in_month(2018, 1, MON, start=arg)
+
+    def test_unsupported_type_get_working_days_delta(self):
+        for arg in self.unsupported:
+            with self.assertRaises(UnsupportedDateType):
+                self.cal.get_working_days_delta(date(2018, 1, 1), arg)
+
+            with self.assertRaises(UnsupportedDateType):
+                self.cal.get_working_days_delta(arg, date(2018, 1, 1))
+
+    def test_datetime(self):
+        self.assertFalse(
+            self.cal.is_working_day(datetime(2014, 1, 1)))
+        self.assertTrue(
+            self.cal.is_holiday(datetime(2014, 1, 1)))
+
+    def test_add_working_days_datetime(self):
+        # datetime inside, date outside
+        self.assertEquals(
+            self.cal.add_working_days(
+                datetime(self.year, 12, 20, 12, 34, 56), 0),
+            date(self.year, 12, 20)
+        )
+        self.assertEquals(
+            self.cal.add_working_days(
+                datetime(self.year, 12, 20, 12, 34, 56), 1),
+            date(self.year, 12, 21)
+        )
+
+        # Use the `keep_datetime` option
+        self.assertEquals(
+            self.cal.add_working_days(
+                datetime(self.year, 12, 20, 12, 34, 56),
+                0, keep_datetime=True),
+            datetime(self.year, 12, 20, 12, 34, 56)
+        )
+        self.assertEquals(
+            self.cal.add_working_days(
+                datetime(self.year, 12, 20, 12, 34, 56),
+                1, keep_datetime=True),
+            datetime(self.year, 12, 21, 12, 34, 56)
+        )
+
+    def test_sub_working_days_datetime(self):
+        # datetime inside, date outside
+        self.assertEquals(
+            self.cal.sub_working_days(
+                datetime(self.year, 12, 20, 12, 34, 56), 0),
+            date(self.year, 12, 20)
+        )
+        self.assertEquals(
+            self.cal.sub_working_days(
+                datetime(self.year, 12, 20, 12, 34, 56), 1),
+            date(self.year, 12, 19)
+        )
+
+        # Use the `keep_datetime` option
+        self.assertEquals(
+            self.cal.sub_working_days(
+                datetime(self.year, 12, 20, 12, 34, 56),
+                0, keep_datetime=True),
+            datetime(self.year, 12, 20, 12, 34, 56)
+        )
+        self.assertEquals(
+            self.cal.sub_working_days(
+                datetime(self.year, 12, 20, 12, 34, 56),
+                1, keep_datetime=True),
+            datetime(self.year, 12, 19, 12, 34, 56)
+        )
+
+    def test_get_holiday_label_with_datetime(self):
+        self.assertEqual(
+            self.cal.get_holiday_label(datetime(2014, 1, 1)), 'New year')
+        self.assertIsNone(
+            self.cal.get_holiday_label(datetime(2014, 1, 2)))
+
+
+class PandasTimestampTest(GenericCalendarTest):
+    cal_class = MockCalendar
+
+    def test_panda_type_is_working_day(self):
+        self.assertFalse(
+            self.cal.is_working_day(pandas.to_datetime("2018-1-1"))
+        )
+
+        # Extra holidays optional argument
+        self.assertFalse(
+            self.cal.is_working_day(
+                date(2018, 1, 2),
+                extra_holidays=[pandas.to_datetime("2018-1-2")]
+            )
+        )
+        # Extra working days optional argument
+        self.assertTrue(
+            self.cal.is_working_day(
+                date(2018, 1, 1),
+                extra_working_days=[pandas.to_datetime("2018-1-1")]
+            )
+        )
+
+    def test_panda_type_is_holiday(self):
+        self.assertTrue(self.cal.is_holiday(pandas.to_datetime("2018-1-1")))
+
+        # Extra holidays optional argument
+        self.assertTrue(
+            self.cal.is_holiday(
+                date(2018, 2, 1),
+                extra_holidays=[pandas.to_datetime("2018-2-1")]
+            )
+        )
+
+    def test_panda_type_holiday_label(self):
+        label = self.cal.get_holiday_label(pandas.to_datetime("2018-1-1"))
+        self.assertEqual(label, "New year")
+
+    def test_panda_type_add_sub_working_days(self):
+        day = pandas.to_datetime("2018-12-24")
+        next_day = self.cal.add_working_days(day, 1)
+        self.assertEqual(next_day, date(2018, 12, 26))
+
+        previous_day = self.cal.sub_working_days(next_day, 1)
+        self.assertEqual(previous_day, date(2018, 12, 24))
+
+        next_day = self.cal.add_working_days(
+            date(2018, 12, 24), 1,
+            extra_holidays=[pandas.to_datetime("2018-12-26")]
+        )
+        self.assertEqual(next_day, date(2018, 12, 27))
+
+        next_day = self.cal.add_working_days(
+            date(2018, 12, 24), 1,
+            extra_working_days=[pandas.to_datetime("2018-12-25")]
+        )
+        self.assertEqual(next_day, date(2018, 12, 25))
+
+    def test_unsupported_type_find_following_working_day(self):
+        following_day = self.cal.find_following_working_day(
+            pandas.to_datetime("2018-1-1")
+        )
+        # No weekend days, the next day is "today"
+        self.assertEqual(following_day, date(2018, 1, 1))
+
+    def test_unsupported_type_get_nth_weekday_in_month(self):
+        start = pandas.to_datetime("2018-1-4")
+        monday = self.cal.get_nth_weekday_in_month(2018, 1, MON, start=start)
+        self.assertEqual(monday, date(2018, 1, 8))
+
+    def test_unsupported_type_get_working_days_delta(self):
+        start, end = date(2018, 12, 23), pandas.to_datetime("2018-12-26")
+        delta = self.cal.get_working_days_delta(start, end)
+        self.assertEqual(delta, 2)
+        delta = self.cal.get_working_days_delta(end, start)
+        self.assertEqual(delta, 2)
+
+        start, end = pandas.to_datetime("2018-12-23"), date(2018, 12, 26)
+        delta = self.cal.get_working_days_delta(start, end)
+        self.assertEqual(delta, 2)
+        delta = self.cal.get_working_days_delta(end, start)
+        self.assertEqual(delta, 2)


### PR DESCRIPTION
* only standard library `date` and `datetime` types (or subtypes) are supported,
* added a new dedicated exception,
* added a paragraph in the documentation about this type support.

refs #294


- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes.
