### PR TITLE
Release/3.2.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,11 @@
 # CHANGELOG
 
-## master (unreleased)
+## v3.2.0 (2018-11-30)
+
+### Major changes
 
 - Removed dependency to `PyEphem`. This package was the "Python2-compatible" library to deal with the xephem system library. Now it's obsolete, so you don't need this dual-dependency handling, because `ephem` is compatible with Python 2 & Python 3 (#296).
-- Raise an exception when trying to use unsupported date/datetime types (#294).
+- Raise an exception when trying to use unsupported date/datetime types. Workalendar now only supports stdlib `date` & `datetime` (sub)types. See the [basic documentation](https://peopledoc.github.io/workalendar/basic.html#standard-datetime-types-only-please) for more details (#294).
 
 ## v3.1.1 (2018-11-17)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## master (unreleased)
+
+Nothing here yet.
+
 ## v3.2.0 (2018-11-30)
 
 ### Major changes

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ REQUIREMENTS = [
     'pyCalverter',
     'setuptools>=1.0',
 ]
-version = '3.2.0.dev0'
+version = '3.2.0'
 __VERSION__ = version
 
 params = dict(

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ REQUIREMENTS = [
     'pyCalverter',
     'setuptools>=1.0',
 ]
-version = '3.2.0'
+version = '3.3.0.dev0'
 __VERSION__ = version
 
 params = dict(


### PR DESCRIPTION
v3.2.0 released on 2018-11-30

### Major changes

- Removed dependency to `PyEphem`. This package was the "Python2-compatible" library to deal with the xephem system library. Now it's obsolete, so you don't need this dual-dependency handling, because `ephem` is compatible with Python 2 & Python 3 (#296).
- Raise an exception when trying to use unsupported date/datetime types. Workalendar now only supports stdlib `date` & `datetime` (sub)types. See the [basic documentation](https://peopledoc.github.io/workalendar/basic.html#standard-datetime-types-only-please) for more details (#294).
