### PR TITLE
Singapore: update DEEPAVALI days up to 2020

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,8 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Added DEEPAVALI days for 2019 and 2020, thx @pvalenti (#282).
+
 
 ## v3.2.0 (2018-11-30)
 

--- a/workalendar/asia/singapore.py
+++ b/workalendar/asia/singapore.py
@@ -45,7 +45,9 @@ class Singapore(WesternCalendar,
         2015: date(2015, 11, 10),
         2016: date(2016, 10, 29),
         2017: date(2017, 10, 18),
-        2018: date(2018, 11, 6)  # This might change
+        2018: date(2018, 11, 6),
+        2019: date(2019, 10, 27),
+        2020: date(2020, 11, 14),   # This might change
     }
     chinese_new_year_label = "Chinese Lunar New Year's Day"
     include_chinese_second_day = True

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -263,6 +263,17 @@ class SingaporeTest(GenericCalendarTest):
         # Shifted day (Monday)
         self.assertIn(date(2016, 5, 2), holidays)
 
+    def test_deepavali(self):
+        # At the moment, we have values for deepavali only until year 2020
+        for year in range(2000, 2021):
+            self.assertIn(year, self.cal.DEEPAVALI)
+
+    def test_deepavali_current_year(self):
+        # This is a regression test. We should be able to have the deepavali
+        # value until this year and probably a few years in the future
+        current_year = date.today().year
+        self.assertIn(current_year, self.cal.DEEPAVALI)
+
 
 class SouthKoreaTest(GenericCalendarTest):
 


### PR DESCRIPTION
superseeds and closes #282

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes.
