### PR TITLE
Bugfix: Resolve incompatibilities between latest Pandas and Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: xenial
 language: python
 install:
     - pip install tox
@@ -24,8 +25,6 @@ matrix:
 
     - python: 3.7
       env: TOXENV=py37
-      # As of September 2018, Python 3.7.0 is not available on "vanilla" travis builds.
-      dist: xenial
       sudo: true
 
     # Lints and others

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+* Solved the incompatibility between `pandas` latest version and Python 3.4. Upgraded travis distro to Xenial/16.04 LTS (#307).
 
 ## v3.2.1 (2018-12-06)
 

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,15 @@
 # -*- coding: utf-8 -*-
 import io
 from os.path import join, dirname, abspath
-import sys
 from setuptools import setup, find_packages
-
-PY2 = sys.version_info[0] == 2
 
 
 def read_relative_file(filename):
-    """Returns contents of the given file, whose path is supposed relative
-    to this module."""
+    """
+    Return the contents of the given file.
+
+    Its path is supposed relative to this module.
+    """
     path = join(dirname(abspath(__file__)), filename)
     with io.open(path, encoding='utf-8') as f:
         return f.read()

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ envlist = py27,flake8,py34,py35,py36,py37,py36-cov,py27-cov
 
 [testenv]
 deps =
-    pandas
+    py34: pandas<0.21
+    !py34: pandas
     pytest
     cov: pytest-cov
 


### PR DESCRIPTION
- Travis job configuration was upgraded to Xenial (16.04)
- ``tox.ini``: conditional requirement. We'll be using the last version of ``pandas`` compatible with Python 3.4, and the latest for other Python versions

refs #306 #304

- [x] Changelog amended with a mention describing your changes.
