### PR TITLE
Add israel calendar

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 - Added New Zealand, by @johnguant (#306).
 - Added Paraguay calendar, following the work of @reichert (#268).
 - Added China calendar, by @iamsk (#304).
+- Added Israel, by @armona, @tsehori (#281)
 
 ## v3.2.1 (2018-12-06)
 

--- a/README.rst
+++ b/README.rst
@@ -136,6 +136,7 @@ Asia
 * Singapore
 * South Korea
 * Taiwan
+* Israel
 
 Oceania
 -------

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ REQUIREMENTS = [
     'lunardate',
     'pytz',
     'pyCalverter',
+    'pyluach',
     'setuptools>=1.0',
 ]
 version = '3.3.0.dev0'

--- a/workalendar/asia/__init__.py
+++ b/workalendar/asia/__init__.py
@@ -7,6 +7,7 @@ from .qatar import Qatar
 from .singapore import Singapore
 from .south_korea import SouthKorea
 from .taiwan import Taiwan
+from .israel import Israel
 
 
 __all__ = (
@@ -18,4 +19,5 @@ __all__ = (
     'Singapore',
     'SouthKorea',
     'Taiwan',
+    'Israel',
 )

--- a/workalendar/asia/israel.py
+++ b/workalendar/asia/israel.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, unicode_literals)
+from datetime import date, timedelta
+
+from pyluach.dates import GregorianDate, HebrewDate
+
+from ..core import Calendar, FRI, SAT
+from ..registry import iso_register
+
+
+@iso_register("IL")
+class Israel(Calendar):
+    "Israel"
+
+    WEEKEND_DAYS = (SAT, FRI)
+
+    def get_variable_days(self, year):
+        days = super(Israel, self).get_variable_days(year)
+
+        delta = timedelta(days=1)
+        current_date = date(year, 1, 1)
+
+        while current_date.year == year:
+            hebrew_date = GregorianDate(
+                year=current_date.year,
+                month=current_date.month,
+                day=current_date.day,
+            ).to_heb()
+
+            jewish_year = hebrew_date.year
+            month = hebrew_date.month
+            day = hebrew_date.day
+
+            if month == 7:
+                if day in {1, 2, 3}:
+                    days.append((current_date, "Rosh Hashana"))
+                elif day == 10:
+                    days.append((current_date, "Yom Kippur"))
+                elif day in range(15, 22):
+                    days.append((current_date, "Sukkot"))
+                elif day == 22:
+                    days.append((current_date, "Shmini Atzeres"))
+            elif month == 12:
+                leap = HebrewDate._is_leap(jewish_year)
+                if day == 14:
+                    days.append((current_date, "Purim"))
+                if day == 15 and not leap:
+                    days.append((current_date, "Purim"))
+            elif month == 13:
+                if day == 14:
+                    days.append((current_date, "Purim"))
+                elif day == 15:
+                    days.append((current_date, "Shushan Purim"))
+            elif month == 1 and day in {15, 21}:
+                days.append((current_date, "Pesach"))
+            elif month == 2:
+                if day == 5:
+                    if hebrew_date.weekday() == 6:
+                        days.append(
+                            (
+                                HebrewDate(jewish_year, month, 4).to_pydate(),
+                                "Independence Day",
+                            )
+                        )
+                    elif hebrew_date.weekday() == 7:
+                        days.append(
+                            (
+                                HebrewDate(jewish_year, month, 3).to_pydate(),
+                                "Independence Day",
+                            )
+                        )
+                    elif hebrew_date.weekday() == 2:
+                        days.append(
+                            (
+                                HebrewDate(jewish_year, month, 6).to_pydate(),
+                                "Independence Day",
+                            )
+                        )
+                    else:
+                        days.append((current_date, "Independence Day"))
+            elif month == 3 and day == 6:
+                days.append((current_date, "Shavout"))
+
+            current_date += delta
+
+        return days

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -1,8 +1,10 @@
 from datetime import date
 from workalendar.tests import GenericCalendarTest
 
-from workalendar.asia import HongKong, Japan, Qatar, Singapore
-from workalendar.asia import SouthKorea, Taiwan, Malaysia, China
+from workalendar.asia import (
+    HongKong, Japan, Qatar, Singapore,
+    SouthKorea, Taiwan, Malaysia, China, Israel
+)
 
 
 class ChinaTest(GenericCalendarTest):
@@ -352,3 +354,48 @@ class TaiwanTest(GenericCalendarTest):
         self.assertIn(date(2012, 4, 4), self.cal.holidays_set(2012))
         self.assertIn(date(2013, 4, 4), self.cal.holidays_set(2013))
         self.assertIn(date(2014, 4, 4), self.cal.holidays_set(2014))
+
+
+class IsraelTest(GenericCalendarTest):
+
+    cal_class = Israel
+
+    def test_holeidays_2017(self):
+        holidays = self.cal.holidays_set(2017)
+
+        self.assertIn(date(2017, 4, 11), holidays)  # Passover (Pesach)
+        self.assertIn(date(2017, 4, 17), holidays)  # Passover (Pesach)
+        self.assertIn(
+            date(2017, 5, 2), holidays
+        )  # Independence Day (Yom Ha-Atzmaut), was early in 2017
+        self.assertIn(date(2017, 5, 31), holidays)  # Shavuot
+        self.assertIn(
+            date(2017, 9, 21), holidays
+        )  # Jewish New Year (Rosh Ha-Shana)
+        self.assertIn(
+            date(2017, 9, 22), holidays
+        )  # Jewish New Year (Rosh Ha-Shana)
+        self.assertIn(
+            date(2017, 9, 30), holidays
+        )  # Yom Kippur (already a Saturday - Shabbat, weekend day)
+        self.assertIn(date(2017, 10, 5), holidays)  # Sukkot
+        self.assertIn(date(2017, 10, 12), holidays)  # Sukkot
+
+    def test_holidays_2018(self):
+        holidays = self.cal.holidays_set(2018)
+
+        self.assertIn(date(2018, 3, 31), holidays)  # Passover (Pesach)
+        self.assertIn(date(2018, 4, 6), holidays)  # Passover (Pesach)
+        self.assertIn(
+            date(2018, 4, 19), holidays
+        )  # Independence Day (Yom Ha-Atzmaut), was delayed in 2018
+        self.assertIn(date(2018, 5, 20), holidays)  # Shavuot
+        self.assertIn(
+            date(2018, 9, 10), holidays
+        )  # Jewish New Year (Rosh Ha-Shana)
+        self.assertIn(
+            date(2018, 9, 11), holidays
+        )  # Jewish New Year (Rosh Ha-Shana)
+        self.assertIn(date(2018, 9, 19), holidays)  # Yom Kippur
+        self.assertIn(date(2018, 9, 24), holidays)  # Sukkot
+        self.assertIn(date(2018, 10, 1), holidays)  # Sukkot


### PR DESCRIPTION
refs #278

Taking over the excellent work by @armona and @tsehori, I've revamped their PR and make it a bit more light, by only keeping editions made to the Changelog, the Readme, and only the patches in the runtime code that were about ``Israel`` calendar class and tests.

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Docstrings for the Calendar class and specific methods.
- [x] Calendar country / label added to the README.rst file,
- [x] Calendar added to the registry,
- [x] Changelog amended with a mention like: "Added ``<country>`` by ``@pseudo`` (#)"

will superseed and thus, closes #281 + close #278.
