### PR TITLE
Release v4.0.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## master (unreleased)
+
+Nothing here yet.
+
 ## 4.0.0 (2019-01-24)
 
 - Solved the incompatibility between `pandas` latest version and Python 3.4. Upgraded travis distro to Xenial/16.04 LTS (#307).

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## master (unreleased)
+## 4.0.0 (2019-01-24)
 
 - Solved the incompatibility between `pandas` latest version and Python 3.4. Upgraded travis distro to Xenial/16.04 LTS (#307).
 - Added instructions about the usage of the `iso_register` decorator in the pull-request template (#309).
@@ -10,7 +10,7 @@
 - Added New Zealand, by @johnguant (#306).
 - Added Paraguay calendar, following the work of @reichert (#268).
 - Added China calendar, by @iamsk (#304).
-- Added Israel, by @armona, @tsehori (#281)
+- Added Israel, by @armona, @tsehori (#281).
 
 ## v3.2.1 (2018-12-06)
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ REQUIREMENTS = [
     'pyluach',
     'setuptools>=1.0',
 ]
-version = '3.3.0.dev0'
+version = '4.0.0'
 __VERSION__ = version
 
 params = dict(

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ REQUIREMENTS = [
     'pyluach',
     'setuptools>=1.0',
 ]
-version = '4.0.0'
+version = '4.1.0.dev0'
 __VERSION__ = version
 
 params = dict(


### PR DESCRIPTION
- Solved the incompatibility between `pandas` latest version and Python
  3.4. Upgraded travis distro to Xenial/16.04 LTS (#307).
- Added instructions about the usage of the `iso_register` decorator in
  the pull-request template (#309).

**New Calendars**

- Added New Zealand, by @johnguant (#306).
- Added Paraguay calendar, following the work of @reichert (#268).
- Added China calendar, by @iamsk (#304).
- Added Israel, by @armona, @tsehori (#281).
