### PR TITLE
Scotland calendars

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New calendars
+
+- Added Scotland calendars, i.e. Scotland, Aberdeen, Angus, Arbroath, Ayr, Carnoustie & Monifieth, Clydebank, Dumfries & Galloway, Dundee, East Dunbartonshire, Edinburgh, Elgin, Falkirk, Fife, Galashiels, Glasgow, Hawick, Inverclyde, Inverness, Kilmarnock, Lochaber, Monifieth, North Lanarkshire, Paisley, Perth, Scottish Borders, South Lanarkshire, Stirling, and West Dunbartonshire (#31).
+
 ### Bugfixes
 
 - Fixed United Kingdom bank holiday for 2002 and 2012 (#315).

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@
 
 ### New calendars
 
+**WARNING** Scotland (sub)calendars are highly experimental and because of their very puzzling rules, may be false. Please use them with care.
+
 - Added Scotland calendars, i.e. Scotland, Aberdeen, Angus, Arbroath, Ayr, Carnoustie & Monifieth, Clydebank, Dumfries & Galloway, Dundee, East Dunbartonshire, Edinburgh, Elgin, Falkirk, Fife, Galashiels, Glasgow, Hawick, Inverclyde, Inverness, Kilmarnock, Lochaber, Monifieth, North Lanarkshire, Paisley, Perth, Scottish Borders, South Lanarkshire, Stirling, and West Dunbartonshire (#31).
 
 ### Bugfixes

--- a/README.rst
+++ b/README.rst
@@ -107,11 +107,11 @@ Europe
 * Russia
 * Slovakia
 * Sweden
-* United Kingdom (incl. Northern Ireland)
 * Spain (incl. Catalonia)
 * Slovenia
 * Switzerland
   * Vaud
+* United Kingdom (incl. Northern Ireland, Scotland and all its territories)
 
 America
 -------

--- a/workalendar/europe/__init__.py
+++ b/workalendar/europe/__init__.py
@@ -40,6 +40,14 @@ from .germany import (
     SaxonyAnhalt, SchleswigHolstein, Thuringia
 )
 
+# Scotland
+from .scotland import (
+    Scotland, Aberdeen, Angus, Arbroath, Ayr, CarnoustieMonifieth, Clydebank,
+    DumfriesGalloway, Dundee, EastDunbartonshire, Edinburgh, Elgin, Falkirk,
+    Fife, Galashiels, Glasgow, Hawick, Inverclyde, Inverness, Kilmarnock,
+    Lanark, Linlithgow, Lochaber, NorthLanarkshire, Paisley, Perth,
+    ScottishBorders, SouthLanarkshire, Stirling, WestDunbartonshire
+)
 
 __all__ = (
     'Austria',
@@ -84,4 +92,12 @@ __all__ = (
     'Bremen', 'Hamburg', 'Hesse', 'MecklenburgVorpommern', 'LowerSaxony',
     'NorthRhineWestphalia', 'RhinelandPalatinate', 'Saarland', 'Saxony',
     'SaxonyAnhalt', 'SchleswigHolstein', 'Thuringia',
+    # Scotland
+    'Scotland',
+    'Aberdeen', 'Angus', 'Arbroath', 'Ayr', 'CarnoustieMonifieth',
+    'Clydebank', 'DumfriesGalloway', 'Dundee', 'EastDunbartonshire',
+    'Edinburgh', 'Elgin', 'Falkirk', 'Fife', 'Galashiels', 'Glasgow',
+    'Hawick', 'Inverclyde', 'Inverness', 'Kilmarnock', 'Lanark', 'Linlithgow',
+    'Lochaber', 'NorthLanarkshire', 'Paisley', 'Perth', 'ScottishBorders',
+    'SouthLanarkshire', 'Stirling', 'WestDunbartonshire'
 )

--- a/workalendar/europe/scotland/__init__.py
+++ b/workalendar/europe/scotland/__init__.py
@@ -23,6 +23,7 @@ FIXME:
 # Since Scotland territories have a lot of different variations, it has become
 # necessary to split this module and associated tests
 from datetime import date, timedelta
+import warnings
 from workalendar.core import WesternCalendar, ChristianMixin
 from workalendar.core import MON, THU, FRI
 from .mixins import (
@@ -63,6 +64,20 @@ class Scotland(WesternCalendar, ChristianMixin):
     include_autumn_holiday = False
     include_saint_andrew = False
     include_victoria_day = False
+
+    def __init__(self, *args, **kwargs):
+        super(Scotland, self).__init__(*args, **kwargs)
+        warnings.warn(
+            """
+Please bear in mind that every Scotland (sub)calendar is highly experimental.
+
+It appeared throughout out searches that Scottish calendars have many
+exceptions and somes sources of information contradicts with each other.
+
+As a consequence, we advise our user to treat this Scotland submodule with
+as much care as possible.
+"""
+        )
 
     def get_may_day(self, year):
         """

--- a/workalendar/europe/scotland/__init__.py
+++ b/workalendar/europe/scotland/__init__.py
@@ -1,0 +1,485 @@
+"""
+Scotland specific module.
+
+The main source of information is:
+https://en.wikipedia.org/wiki/Public_and_bank_holidays_in_Scotland
+
+Note on "inheritance":
+
+* Carnoustie and Monifieth area is a subdivision of Angus
+* Lanark is part of South Lanarkshire
+
+FIXME:
+
+* Galashiels is part of the Scottish Borders
+* Hawick is part of the Scottish Borders
+* Kilmarnock is probably part of AyrShire (?)
+* Lanark is part of South Lanarkshire
+* Linlithgow... part of N/A
+* Lochaber... part of N/A
+* ...
+
+"""
+# Since Scotland territories have a lot of different variations, it has become
+# necessary to split this module and associated tests
+from datetime import date, timedelta
+from workalendar.core import WesternCalendar, ChristianMixin
+from workalendar.core import MON, THU, FRI
+from .mixins import (
+    SpringHolidayFirstMondayApril,
+    SpringHolidaySecondMondayApril,
+    SpringHolidayTuesdayAfterFirstMondayMay,
+    SpringHolidayLastMondayMay,
+    SpringHolidayFirstMondayJune,
+    VictoriaDayFourthMondayMay,
+    VictoriaDayLastMondayMay,
+    VictoriaDayFirstMondayJune,
+    FairHolidayLastMondayJune,
+    FairHolidayFirstMondayJuly,
+    FairHolidaySecondMondayJuly,
+    FairHolidayThirdMondayJuly,
+    FairHolidayLastMondayJuly,
+    FairHolidayFourthFridayJuly,
+    FairHolidayFirstMondayAugust,
+    LateSummer,
+    BattleStirlingBridge,
+    AutumnHolidayLastMondaySeptember,
+    AutumnHolidayFirstMondayOctober,
+    AutumnHolidaySecondMondayOctober,
+    AutumnHolidayThirdMondayOctober,
+    AyrGoldCup,
+)
+
+
+class Scotland(WesternCalendar, ChristianMixin):
+    "Scotland"
+    FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
+        (1, 2, "New Year Holiday"),
+        (12, 26, "Boxing Day"),
+    )
+    include_spring_holiday = False
+    spring_holiday_label = "Spring Holiday"
+    include_fair_holiday = False
+    include_autumn_holiday = False
+    include_saint_andrew = False
+    include_victoria_day = False
+
+    def get_may_day(self, year):
+        """
+        May Day is the first Monday in May
+        """
+        return (
+            Scotland.get_nth_weekday_in_month(year, 5, MON),
+            "May Day"
+        )
+
+    def get_spring_holiday(self, year):
+        """
+        Return spring holiday date and label.
+
+        You need to implement it as soon as the flag `include_spring_holiday`
+        is True.
+        """
+        raise NotImplementedError(
+            "Tried to add spring holiday while "
+            "`get_spring_holiday` is not implemented.")
+
+    def get_fair_holiday(self, year):
+        """
+        Return fair holiday date and label.
+
+        You need to implement it as soon as the flag `include_fair_holiday`
+        is True.
+        """
+        raise NotImplementedError(
+            "Tried to add fair holiday while "
+            "`get_fair_holiday` is not implemented.")
+
+    def get_autumn_holiday(self, year):
+        """
+        Return autumn holiday date and label.
+
+        You need to implement it as soon as the flag `include_autumn_holiday`
+        is True.
+        """
+        raise NotImplementedError(
+            "Tried to add autumn holiday while "
+            "`get_autumn_holiday` is not implemented.")
+
+    def get_victoria_day(self, year):
+        """
+        Return Victoria day date and label.
+
+        You need to implement it as soon as the flag `include_victoria_day`
+        is True.
+        """
+        raise NotImplementedError(
+            "Tried to add autumn holiday while "
+            "`include_victoria_day` is not implemented.")
+
+    def get_variable_days(self, year):
+        days = super(Scotland, self).get_variable_days(year)
+        days.append(self.get_may_day(year))
+        if self.include_spring_holiday:
+            # This method is included in the spring_holiday mixins
+            days.append(self.get_spring_holiday(year))
+        if self.include_fair_holiday:
+            # This method is included in the fair_holiday mixins
+            days.append(self.get_fair_holiday(year))
+        if self.include_autumn_holiday:
+            # This method is included in the autumn_holiday mixins
+            days.append(self.get_autumn_holiday(year))
+        if self.include_victoria_day:
+            # This method is included in the victoria_day mixins
+            days.append(self.get_victoria_day(year))
+        return days
+
+    def get_fixed_holidays(self, year):
+        days = super(Scotland, self).get_fixed_holidays(year)
+        if self.include_saint_andrew:
+            days.append((date(year, 11, 30), "Saint Andrew's Day"))
+        return days
+
+
+class Aberdeen(
+        FairHolidaySecondMondayJuly,
+        AutumnHolidayLastMondaySeptember,
+        Scotland):
+    "Aberdeen"
+    include_good_friday = True
+
+
+class Angus(
+        SpringHolidaySecondMondayApril,
+        AutumnHolidayLastMondaySeptember,
+        Scotland):
+    "Angus"
+    include_saint_andrew = True
+
+
+class Arbroath(FairHolidayThirdMondayJuly, Scotland):
+    "Arbroath"
+
+
+class Ayr(SpringHolidayLastMondayMay, AyrGoldCup, Scotland):
+    "Ayr"
+    include_good_friday = True
+    include_easter_monday = True
+
+
+class CarnoustieMonifieth(
+        SpringHolidayFirstMondayApril,
+        AutumnHolidayFirstMondayOctober,
+        Scotland):
+    "Carnoustie & Monifieth"
+
+
+class Clydebank(
+        SpringHolidayTuesdayAfterFirstMondayMay,
+        Scotland):
+    "Clydebank"
+
+
+class DumfriesGalloway(Scotland):
+    "Dumfries & Galloway"
+    include_good_friday = True
+
+
+class Dundee(
+        SpringHolidayFirstMondayApril,
+        VictoriaDayLastMondayMay,
+        FairHolidayLastMondayJuly,
+        AutumnHolidayFirstMondayOctober,
+        Scotland):
+    "Dundee"
+
+
+class EastDunbartonshire(
+        SpringHolidayLastMondayMay,
+        FairHolidayThirdMondayJuly,
+        AutumnHolidayLastMondaySeptember,
+        Scotland):
+    "East Dunbartonshire"
+    include_good_friday = True
+    include_easter_monday = True
+
+
+class Edinburgh(Scotland):
+    "Edinburgh"
+    include_good_friday = True
+    include_easter_monday = True
+    include_spring_holiday = True
+    include_victoria_day = True
+    include_autumn_holiday = True
+
+    def get_spring_holiday(self, year):
+        """
+        Return Spring Holiday for Edinburgh.
+
+        Set to the 3rd Monday of April, unless it falls on Easter Monday, then
+        it's shifted to previous week.
+        """
+        easter = self.get_easter_monday(year)
+        spring_holiday = self.get_nth_weekday_in_month(year, 4, MON, 3)
+        if easter == spring_holiday:
+            spring_holiday = self.get_nth_weekday_in_month(
+                year, 4, MON, 2)
+
+        return (spring_holiday, self.spring_holiday_label)
+
+    def get_victoria_day(self, year):
+        """
+        Return Victoria Day for Edinburgh.
+
+        Set to the Monday strictly before May 24th. It means that if May 24th
+        is a Monday, it's shifted to the week before.
+        """
+        may_24th = date(year, 5, 24)
+        # Since "MON(day) == 0", it's either the difference between MON and the
+        # current weekday (starting at 0), or 7 days before the May 24th
+        shift = may_24th.weekday() or 7
+        victoria_day = may_24th - timedelta(days=shift)
+        return (victoria_day, "Victoria Day")
+
+    def get_autumn_holiday(self, year):
+        """
+        Return Autumn Holiday for Edinburgh.
+
+        Set to the third Monday in September. Since it's the only region to
+        follow this rule, we won't have a Mixin associated to it.
+        """
+        return (
+            self.get_nth_weekday_in_month(year, 9, MON, 3),
+            "Autumn Holiday"
+        )
+
+
+class Elgin(
+        SpringHolidaySecondMondayApril,
+        FairHolidayLastMondayJune,
+        LateSummer,
+        AutumnHolidayThirdMondayOctober,
+        Scotland):
+    "Elgin"
+
+
+class Falkirk(FairHolidayFirstMondayJuly, BattleStirlingBridge, Scotland):
+    "Falkirk"
+    include_good_friday = True
+    include_easter_monday = True
+
+
+class Fife(
+        VictoriaDayFirstMondayJune,
+        FairHolidayThirdMondayJuly,
+        AutumnHolidayThirdMondayOctober,
+        Scotland):
+    "Fife"
+    include_saint_andrew = True
+
+    def get_variable_days(self, year):
+        days = super(Fife, self).get_variable_days(year)
+        # Special computation rule, Fife has TWO spring holidays
+        # 1. First Monday in April
+        days.append((
+            self.get_nth_weekday_in_month(year, 4, MON),
+            "Spring Holiday"
+        ))
+        # 2. First Monday in June
+        days.append((
+            self.get_nth_weekday_in_month(year, 6, MON),
+            "Spring Holiday"
+        ))
+        return days
+
+
+class Galashiels(SpringHolidayFirstMondayJune, Scotland):
+    "Galashiels"
+
+    def get_variable_days(self, year):
+        days = super(Galashiels, self).get_variable_days(year)
+        # Adding Braw Lads Gathering, 1st Friday in July
+        days.append((
+            self.get_nth_weekday_in_month(year, 7, FRI),
+            "Braw Lads Gathering"
+        ))
+        return days
+
+
+class Glasgow(
+        SpringHolidayLastMondayMay,
+        FairHolidayThirdMondayJuly,
+        AutumnHolidayLastMondaySeptember,
+        Scotland):
+    "Glasgow"
+    include_easter_monday = True
+
+
+class Hawick(Scotland):
+    "Hawick"
+
+    def get_variable_days(self, year):
+        days = super(Hawick, self).get_variable_days(year)
+        # Common Riding happens on the FRI after the first MON in June
+        first_monday = self.get_nth_weekday_in_month(year, 6, MON)
+        friday = first_monday + timedelta(days=4)
+        # And on the saturday. Adding this one, even if SAT is already a
+        # non-working day.
+        saturday = first_monday + timedelta(days=5)
+        days.append((friday, "Common Riding Day 1"))
+        days.append((saturday, "Common Riding Day 2"))
+        return days
+
+
+class Inverclyde(LateSummer, Scotland):
+    "Inverclyde"
+    include_good_friday = True
+    include_easter_monday = True
+
+    def get_variable_days(self, year):
+        days = super(Inverclyde, self).get_variable_days(year)
+        # Special computation rule, Inverclyde has TWO spring holidays
+        # 1. First Monday in April
+        days.append((
+            self.get_last_weekday_in_month(year, 4, MON),
+            "Spring Holiday"
+        ))
+        # 2. First Monday in June
+        days.append((
+            self.get_nth_weekday_in_month(year, 6, MON),
+            "Spring Holiday"
+        ))
+        return days
+
+
+class Inverness(
+        SpringHolidayFirstMondayApril,
+        FairHolidayFirstMondayJuly,
+        AutumnHolidayFirstMondayOctober,
+        Scotland):
+    "Inverness"
+
+    def get_variable_days(self, year):
+        days = super(Inverness, self).get_variable_days(year)
+        days.append((
+            self.get_nth_weekday_in_month(year, 2, MON),
+            "Winter Holiday (February)"
+        ))
+        days.append((
+            self.get_nth_weekday_in_month(year, 3, MON),
+            "Winter Holiday (March)"
+        ))
+        days.append((
+            self.get_nth_weekday_in_month(year, 11, MON),
+            "Samhain Holiday"
+        ))
+        return days
+
+
+class Kilmarnock(AyrGoldCup, Scotland):
+    "Kilmarnock"
+    include_good_friday = True
+    include_easter_monday = True
+
+
+class Lanark(Scotland):
+    "Lanark"
+
+    def get_variable_days(self, year):
+        days = super(Lanark, self).get_variable_days(year)
+        # Lanimer is 2nd THU in June
+        days.append((
+            self.get_nth_weekday_in_month(year, 6, THU, 2),
+            "Lanimer Day"
+        ))
+        return days
+
+
+class Linlithgow(Scotland):
+    "Linlithgow"
+    def get_variable_days(self, year):
+        days = super(Linlithgow, self).get_variable_days(year)
+        # Linlithgow Marches is on TUE after the 2nd THU in June
+        second_thursday = self.get_nth_weekday_in_month(year, 6, THU, 2)
+        marches_day = second_thursday + timedelta(days=5)
+        days.append((
+            marches_day,
+            "Linlithgow Marches"
+        ))
+        return days
+
+
+class Lochaber(Scotland):
+    "Lochaber"
+    def get_variable_days(self, year):
+        days = super(Lochaber, self).get_variable_days(year)
+        # Winter holiday is on the last MON of march
+        days.append((
+            self.get_last_weekday_in_month(year, 3, MON),
+            "Winter holiday"
+        ))
+        return days
+
+
+class NorthLanarkshire(
+        SpringHolidayLastMondayMay,
+        FairHolidayThirdMondayJuly,
+        AutumnHolidayLastMondaySeptember,
+        Scotland):
+    "North Lanarkshire"
+    include_easter_monday = True
+
+
+class Paisley(
+        VictoriaDayLastMondayMay,
+        FairHolidayFirstMondayAugust,
+        AutumnHolidayLastMondaySeptember,
+        Scotland):
+    "Paisley"
+    include_good_friday = True
+    include_easter_monday = True
+
+
+class Perth(
+        SpringHolidayFirstMondayApril,
+        VictoriaDayFourthMondayMay,
+        BattleStirlingBridge,
+        AutumnHolidayFirstMondayOctober,
+        Scotland):
+    "Perth"
+
+
+class ScottishBorders(
+        SpringHolidayFirstMondayApril,
+        FairHolidayFourthFridayJuly,
+        AutumnHolidaySecondMondayOctober,
+        Scotland):
+    "Scottish Borders"
+    include_saint_andrew = True
+
+
+class SouthLanarkshire(
+        SpringHolidayLastMondayMay,
+        FairHolidayThirdMondayJuly,
+        AutumnHolidayLastMondaySeptember,
+        Scotland):
+    "South Lanarkshire"
+    include_good_friday = True
+    include_easter_monday = True
+
+
+class Stirling(
+        SpringHolidayTuesdayAfterFirstMondayMay,
+        BattleStirlingBridge,
+        Scotland):
+    "Stirling"
+    include_good_friday = True
+    include_easter_monday = True
+
+
+class WestDunbartonshire(
+        AutumnHolidayLastMondaySeptember,
+        Scotland):
+    "West Dunbartonshire"
+    include_good_friday = True
+    include_easter_monday = True

--- a/workalendar/europe/scotland/mixins/__init__.py
+++ b/workalendar/europe/scotland/mixins/__init__.py
@@ -1,0 +1,104 @@
+"""
+Scotland calendar mixins.
+
+There are so many of them that it became necessary to move them to a different
+module.
+"""
+from workalendar.core import MON, FRI
+from datetime import timedelta
+
+from .spring_holiday import (
+    SpringHolidayFirstMondayApril,
+    SpringHolidaySecondMondayApril,
+    SpringHolidayTuesdayAfterFirstMondayMay,
+    SpringHolidayLastMondayMay,
+    SpringHolidayFirstMondayJune,
+)
+
+from .fair_holiday import (
+    FairHolidayLastMondayJune,
+    FairHolidayFirstMondayJuly,
+    FairHolidaySecondMondayJuly,
+    FairHolidayThirdMondayJuly,
+    FairHolidayLastMondayJuly,
+    FairHolidayFourthFridayJuly,
+    FairHolidayFirstMondayAugust,
+)
+
+from .victoria_day import (
+    VictoriaDayFourthMondayMay,
+    VictoriaDayLastMondayMay,
+    VictoriaDayFirstMondayJune,
+)
+
+from .autumn_holiday import (
+    AutumnHolidayLastMondaySeptember,
+    AutumnHolidayFirstMondayOctober,
+    AutumnHolidaySecondMondayOctober,
+    AutumnHolidayThirdMondayOctober,
+)
+
+
+class LateSummer(object):
+    def get_variable_days(self, year):
+        """
+        Add Late Summer holiday (First Monday of September)
+        """
+        days = super(LateSummer, self).get_variable_days(year)
+        days.append((
+            self.get_nth_weekday_in_month(year, 9, MON),
+            "Late Summer Holiday"
+        ))
+        return days
+
+
+class BattleStirlingBridge(object):
+    def get_variable_days(self, year):
+        """
+        Add Battle of Stirling Bridge holiday (Second Monday of September)
+        """
+        days = super(BattleStirlingBridge, self).get_variable_days(year)
+        days.append((
+            self.get_nth_weekday_in_month(year, 9, MON, 2),
+            "Battle of Stirling Bridge Holiday"
+        ))
+        return days
+
+
+class AyrGoldCup(object):
+    def get_variable_days(self, year):
+        days = super(AyrGoldCup, self).get_variable_days(year)
+        # Ayr Gold Cup
+        gold_cup_friday = self.get_nth_weekday_in_month(year, 9, FRI, 3)
+        days.append(
+            (gold_cup_friday, "Ayr Gold Cup Friday")
+        )
+        days.append(
+            (gold_cup_friday + timedelta(days=3), "Ayr Gold Cup Monday")
+        )
+        return days
+
+
+__all__ = [
+    'AyrGoldCup',
+    'SpringHolidayFirstMondayApril',
+    'SpringHolidaySecondMondayApril',
+    'SpringHolidayTuesdayAfterFirstMondayMay',
+    'SpringHolidayLastMondayMay',
+    'SpringHolidayFirstMondayJune',
+    'VictoriaDayFourthMondayMay',
+    'VictoriaDayLastMondayMay',
+    'VictoriaDayTuesdayAfterFirstMondayMay',
+    'VictoriaDayFirstMondayJune',
+    'FairHolidayLastMondayJune',
+    'FairHolidayFirstMondayJuly',
+    'FairHolidaySecondMondayJuly',
+    'FairHolidayThirdMondayJuly',
+    'FairHolidayLastMondayJuly',
+    'FairHolidayFourthFridayJuly',
+    'FairHolidayFirstMondayAugust',
+    'AutumnHolidayLastMondaySeptember',
+    'AutumnHolidayFirstMondayOctober',
+    'AutumnHolidaySecondMondayOctober',
+    'AutumnHolidayThirdMondayOctober',
+]

--- a/workalendar/europe/scotland/mixins/autumn_holiday.py
+++ b/workalendar/europe/scotland/mixins/autumn_holiday.py
@@ -1,0 +1,41 @@
+"""
+Autumn Holiday mixins
+"""
+from workalendar.core import MON
+
+
+class AutumHoliday(object):
+    include_autumn_holiday = True
+    autumn_holiday_label = "Autumn Holiday"
+
+
+class AutumnHolidayLastMondaySeptember(AutumHoliday):
+    def get_autumn_holiday(self, year):
+        return (
+            self.get_last_weekday_in_month(year, 9, MON),
+            self.autumn_holiday_label
+        )
+
+
+class AutumnHolidayFirstMondayOctober(AutumHoliday):
+    def get_autumn_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 10, MON),
+            self.autumn_holiday_label
+        )
+
+
+class AutumnHolidaySecondMondayOctober(AutumHoliday):
+    def get_autumn_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 10, MON, 2),
+            self.autumn_holiday_label
+        )
+
+
+class AutumnHolidayThirdMondayOctober(AutumHoliday):
+    def get_autumn_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 10, MON, 3),
+            self.autumn_holiday_label
+        )

--- a/workalendar/europe/scotland/mixins/fair_holiday.py
+++ b/workalendar/europe/scotland/mixins/fair_holiday.py
@@ -1,0 +1,72 @@
+"""
+Fair Holiday mixins
+"""
+from workalendar.core import MON, FRI
+
+
+class FairHoliday(object):
+    include_fair_holiday = True
+    fair_holiday_label = "Fair Holiday"
+
+
+class FairHolidayLastMondayJune(FairHoliday):
+
+    def get_fair_holiday(self, year):
+        return (
+            self.get_last_weekday_in_month(year, 6, MON),
+            self.fair_holiday_label
+        )
+
+
+class FairHolidayFirstMondayJuly(FairHoliday):
+
+    def get_fair_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 7, MON),
+            self.fair_holiday_label
+        )
+
+
+class FairHolidaySecondMondayJuly(FairHoliday):
+
+    def get_fair_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 7, MON, 2),
+            self.fair_holiday_label
+        )
+
+
+class FairHolidayThirdMondayJuly(FairHoliday):
+
+    def get_fair_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 7, MON, 3),
+            self.fair_holiday_label
+        )
+
+
+class FairHolidayLastMondayJuly(FairHoliday):
+
+    def get_fair_holiday(self, year):
+        return (
+            self.get_last_weekday_in_month(year, 7, MON),
+            self.fair_holiday_label
+        )
+
+
+class FairHolidayFourthFridayJuly(FairHoliday):
+
+    def get_fair_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 7, FRI, 4),
+            self.fair_holiday_label
+        )
+
+
+class FairHolidayFirstMondayAugust(FairHoliday):
+
+    def get_fair_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 8, MON),
+            self.fair_holiday_label
+        )

--- a/workalendar/europe/scotland/mixins/spring_holiday.py
+++ b/workalendar/europe/scotland/mixins/spring_holiday.py
@@ -1,0 +1,52 @@
+"""
+Spring Holiday mixins
+"""
+from datetime import timedelta
+
+from workalendar.core import MON
+
+
+class SpringHoliday(object):
+    include_spring_holiday = True
+
+
+class SpringHolidayFirstMondayApril(SpringHoliday):
+    def get_spring_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 4, MON),
+            self.spring_holiday_label
+        )
+
+
+class SpringHolidaySecondMondayApril(SpringHoliday):
+    def get_spring_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 4, MON, 2),
+            self.spring_holiday_label
+        )
+
+
+class SpringHolidayTuesdayAfterFirstMondayMay(SpringHoliday):
+
+    def get_spring_holiday(self, year):
+        first_monday = self.get_nth_weekday_in_month(year, 5, MON)
+        return (
+            first_monday + timedelta(days=1),
+            self.spring_holiday_label
+        )
+
+
+class SpringHolidayLastMondayMay(SpringHoliday):
+    def get_spring_holiday(self, year):
+        return (
+            self.get_last_weekday_in_month(year, 5, MON),
+            self.spring_holiday_label
+        )
+
+
+class SpringHolidayFirstMondayJune(SpringHoliday):
+    def get_spring_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 6, MON),
+            self.spring_holiday_label
+        )

--- a/workalendar/europe/scotland/mixins/victoria_day.py
+++ b/workalendar/europe/scotland/mixins/victoria_day.py
@@ -1,0 +1,36 @@
+"""
+Victoria Day mixins
+"""
+from workalendar.core import MON
+
+
+class VictoriaDayMixin(object):
+    include_victoria_day = True
+    victoria_day_label = "Victoria Day"
+
+
+class VictoriaDayFourthMondayMay(VictoriaDayMixin):
+
+    def get_victoria_day(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 5, MON, 4),
+            self.victoria_day_label
+        )
+
+
+class VictoriaDayLastMondayMay(VictoriaDayMixin):
+
+    def get_victoria_day(self, year):
+        return (
+            self.get_last_weekday_in_month(year, 5, MON),
+            self.victoria_day_label
+        )
+
+
+class VictoriaDayFirstMondayJune(VictoriaDayMixin):
+
+    def get_victoria_day(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 6, MON),
+            self.victoria_day_label
+        )

--- a/workalendar/tests/__init__.py
+++ b/workalendar/tests/__init__.py
@@ -9,6 +9,7 @@ class GenericCalendarTest(TestCase):
     cal_class = Calendar
 
     def setUp(self):
-        warnings.simplefilter("ignore")
+        super(GenericCalendarTest, self).setUp()
+        warnings.simplefilter('ignore')
         self.year = date.today().year
         self.cal = self.cal_class()

--- a/workalendar/tests/test_scotland.py
+++ b/workalendar/tests/test_scotland.py
@@ -1,0 +1,607 @@
+from datetime import date
+from unittest import TestCase
+
+from workalendar.tests import GenericCalendarTest
+from workalendar.europe import (
+    Scotland, Aberdeen, Angus, Arbroath, Ayr, CarnoustieMonifieth, Clydebank,
+    DumfriesGalloway, Dundee, EastDunbartonshire, Edinburgh, Elgin, Falkirk,
+    Fife, Galashiels, Glasgow, Hawick, Inverclyde, Inverness, Kilmarnock,
+    Lanark, Linlithgow, Lochaber, NorthLanarkshire, Paisley, Perth,
+    ScottishBorders, SouthLanarkshire, Stirling, WestDunbartonshire,
+)
+
+
+class GoodFridayTestMixin(object):
+    def test_good_friday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 3, 30), holidays)
+
+
+class EasterMondayTestMixin(object):
+    def test_easter_monday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 4, 2), holidays)
+
+
+class SpringHolidayFirstMondayAprilTestMixin(object):
+    def test_spring_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 4, 2), holidays)
+
+
+class SpringHolidaySecondMondayAprilTestMixin(object):
+    def test_spring_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 4, 9), holidays)
+
+
+class SpringHolidayLastMondayMayTestMixin(object):
+    def test_spring_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 5, 28), holidays)
+
+
+class FairHolidayLastMondayJuneTestMixin(object):
+    def test_fair_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 6, 25), holidays)
+
+
+class FairHolidayFirstMondayJulyTestMixin(object):
+    def test_fair_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 7, 2), holidays)
+
+
+class FairHolidaySecondMondayJulyTestMixin(object):
+    def test_fair_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 7, 9), holidays)
+
+
+class FairHolidayThirdMondayJulyTestMixin(object):
+    def test_fair_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 7, 16), holidays)
+
+
+class FairHolidayLastMondayJulyTestMixin(object):
+    def test_fair_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 7, 30), holidays)
+
+
+class FairHolidayFourthFridayJulyTestMixin(object):
+    def test_fair_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 7, 27), holidays)
+
+
+class FairHolidayFirstMondayAugustTestMixin(object):
+    def test_fair_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 8, 6), holidays)
+
+
+class LateSummerTestMixin(object):
+    def test_late_summer(self):
+        # First monday of september
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 9, 3), holidays)
+
+
+class BattleStirlingBridgeTestMixin(object):
+    def test_stirling(self):
+        # Second monday of september
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 9, 10), holidays)
+
+
+class AutumnHolidayLastMondaySeptemberTestMixin(object):
+    def test_autumn_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 9, 24), holidays)
+
+
+class AutumnHolidayFirstMondayOctoberTestMixin(object):
+    def test_autumn_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 10, 1), holidays)
+
+
+class AutumnHolidaySecondMondayOctoberTestMixin(object):
+    def test_autumn_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 10, 8), holidays)
+
+
+class AutumnHolidayThirdMondayOctoberTestMixin(object):
+    def test_autumn_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 10, 15), holidays)
+
+
+class SaintAndrewTestMixin(object):
+    def test_saint_andrew(self):
+        # St. Andrew's day happens on November 30th
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 11, 30), holidays)
+
+
+class VictoriaDayLastMondayMayTestMixin(object):
+    def test_victoria_day(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 5, 28), holidays)
+
+
+class SpringHolidayTuesdayAfterFirstMondayMayTestMixin(object):
+    def test_spring_holiday_2018(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 5, 8), holidays)
+
+    def test_spring_holiday_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 5, 2), holidays)
+
+
+class VictoriaDayFirstMondayJuneTestMixin(object):
+    def test_victoria_day(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 6, 4), holidays)
+
+
+class VictoriaDayFourthMondayMayTestMixin(object):
+    def test_victoria_day(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 5, 28), holidays)
+
+
+class AyrGoldCupTestMixin(object):
+    """
+    Ayr Gold cup - two holidays for Ayr and Kilmarnock
+    """
+    def test_ayr_gold_cup(self):
+        # Specific holidays in Ayr:
+        # * 3rd Friday in September
+        # * + the following Monday
+        holidays = self.cal.holidays_set(2018)
+        gold_cup_friday = date(2018, 9, 21)
+        gold_cup_monday = date(2018, 9, 24)
+        self.assertIn(gold_cup_friday, holidays)
+        self.assertIn(gold_cup_monday, holidays)
+        # Testing labels
+        holidays = self.cal.holidays(2018)
+        holidays_dict = dict(holidays)
+        self.assertEqual(holidays_dict[gold_cup_friday], "Ayr Gold Cup Friday")
+        self.assertEqual(holidays_dict[gold_cup_monday], "Ayr Gold Cup Monday")
+
+
+# -----------------------------------------------------------------------------
+class SpringHolidayTestCase(TestCase):
+
+    def test_not_implemented_error(self):
+        class FakeCalendar(Scotland):
+            include_spring_holiday = True
+
+        cal = FakeCalendar()
+        with self.assertRaises(NotImplementedError):
+            cal.holidays_set(2018)
+
+    def test_correct_implementation(self):
+        class FakeCalendar(Scotland):
+            include_spring_holiday = True
+
+            def get_spring_holiday(self, year):
+                return (date(year, 1, 1), "Spring Holiday")
+
+        cal = FakeCalendar()
+        self.assertTrue(cal.holidays_set(2018))
+
+
+class VictoriaDayTestCase(TestCase):
+
+    def test_not_implemented_error(self):
+        class FakeCalendar(Scotland):
+            include_victoria_day = True
+
+        cal = FakeCalendar()
+        with self.assertRaises(NotImplementedError):
+            cal.holidays_set(2018)
+
+    def test_correct_implementation(self):
+        class FakeCalendar(Scotland):
+            include_victoria_day = True
+
+            def get_victoria_day(self, year):
+                return (date(year, 1, 1), "Victoria Day")
+
+        cal = FakeCalendar()
+        self.assertTrue(cal.holidays_set(2018))
+
+
+class FairHolidayTestCase(TestCase):
+
+    def test_not_implemented_error(self):
+        class FakeCalendar(Scotland):
+            include_fair_holiday = True
+
+        cal = FakeCalendar()
+        with self.assertRaises(NotImplementedError):
+            cal.holidays_set(2018)
+
+    def test_correct_implementation(self):
+        class FakeCalendar(Scotland):
+            include_fair_holiday = True
+
+            def get_fair_holiday(self, year):
+                return (date(year, 1, 1), "Fair Holiday")
+
+        cal = FakeCalendar()
+        self.assertTrue(cal.holidays_set(2018))
+
+
+class AutumnHolidayTestCase(TestCase):
+
+    def test_not_implemented_error(self):
+        class FakeCalendar(Scotland):
+            include_autumn_holiday = True
+
+        cal = FakeCalendar()
+        with self.assertRaises(NotImplementedError):
+            cal.holidays_set(2018)
+
+    def test_correct_implementation(self):
+        class FakeCalendar(Scotland):
+            include_autumn_holiday = True
+
+            def get_autumn_holiday(self, year):
+                return (date(year, 1, 1), "Autumn Holiday")
+
+        cal = FakeCalendar()
+        self.assertTrue(cal.holidays_set(2018))
+
+
+class ScotlandTest(GenericCalendarTest):
+    """
+    Generic Scotland test calendar.
+
+    Scotland calendar includes the generic holidays + GoodFriday
+    Some towns or cities don't necessarily observe it.
+    """
+    cal_class = Scotland
+
+    def test_year_2018(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 1, 1), holidays)  # New year's day
+        self.assertIn(date(2018, 1, 2), holidays)  # New year holiday
+        self.assertIn(date(2018, 5, 7), holidays)  # May day
+        self.assertIn(date(2018, 12, 25), holidays)  # XMas
+        self.assertIn(date(2018, 12, 26), holidays)  # Boxing day
+
+    def test_good_friday(self):
+        # By default, Good Friday is not a holiday
+        holidays = self.cal.holidays_set(2018)
+        self.assertNotIn(date(2018, 3, 30), holidays)
+
+
+class ScotlandAberdeenTest(
+        GoodFridayTestMixin,
+        FairHolidaySecondMondayJulyTestMixin,
+        AutumnHolidayLastMondaySeptemberTestMixin,
+        ScotlandTest):
+    cal_class = Aberdeen
+
+
+class ScotlandAngusTest(
+        SpringHolidaySecondMondayAprilTestMixin,
+        AutumnHolidayLastMondaySeptemberTestMixin,
+        SaintAndrewTestMixin,
+        ScotlandTest):
+    cal_class = Angus
+
+
+class ScotlandArbroathTest(
+        FairHolidayThirdMondayJulyTestMixin, ScotlandTest):
+    cal_class = Arbroath
+
+
+class ScotlandAyrTest(
+        GoodFridayTestMixin,
+        EasterMondayTestMixin,
+        SpringHolidayLastMondayMayTestMixin,
+        AyrGoldCupTestMixin,
+        ScotlandTest):
+    cal_class = Ayr
+
+
+class ScotlandCarnoustieMonifiethTest(
+        SpringHolidayFirstMondayAprilTestMixin,
+        AutumnHolidayFirstMondayOctoberTestMixin,
+        ScotlandTest):
+    cal_class = CarnoustieMonifieth
+
+
+class ScotlandClydebankTest(
+        SpringHolidayTuesdayAfterFirstMondayMayTestMixin,
+        ScotlandTest):
+    cal_class = Clydebank
+
+
+class ScotlandDumfriesGallowayTest(GoodFridayTestMixin, ScotlandTest):
+    cal_class = DumfriesGalloway
+
+
+class ScotlandDundeeTest(
+        SpringHolidayFirstMondayAprilTestMixin,
+        VictoriaDayLastMondayMayTestMixin,
+        FairHolidayLastMondayJulyTestMixin,
+        AutumnHolidayFirstMondayOctoberTestMixin,
+        ScotlandTest):
+    cal_class = Dundee
+
+
+class ScotlandEastDunbartonshireTest(
+        GoodFridayTestMixin, EasterMondayTestMixin,
+        SpringHolidayLastMondayMayTestMixin,
+        FairHolidayThirdMondayJulyTestMixin,
+        AutumnHolidayLastMondaySeptemberTestMixin,
+        ScotlandTest):
+    cal_class = EastDunbartonshire
+
+
+class ScotlandEdinburghTest(
+        GoodFridayTestMixin, EasterMondayTestMixin,
+        ScotlandTest):
+    cal_class = Edinburgh
+
+    def test_edinburgh_spring_holiday(self):
+        # Stated as the 3rd Monday in April...
+        holidays = self.cal.holidays_set(2018)
+        spring_holiday = date(2018, 4, 16)
+        self.assertIn(spring_holiday, holidays)
+        # ... except if it falls on Easter Monday
+        # Then it's shifted to the previous week.
+        # That was the case in 2017
+        holidays = self.cal.holidays(2017)
+        holidays_dict = dict(holidays)
+        easter_monday = date(2017, 4, 17)
+        spring_holiday = date(2017, 4, 10)
+        self.assertIn(easter_monday, holidays_dict)
+        self.assertIn(spring_holiday, holidays_dict)
+        self.assertEqual(holidays_dict[easter_monday], "Easter Monday")
+        self.assertEqual(holidays_dict[spring_holiday], "Spring Holiday")
+
+    def test_edinburgh_victoria_day(self):
+        # The Monday strictly before May 24th
+        holidays = self.cal.holidays_set(2018)
+        victoria_day = date(2018, 5, 21)
+        self.assertIn(victoria_day, holidays)
+        # In 2010, May 24th was a monday, so Victoria Day is on 17th.
+        holidays = self.cal.holidays_set(2010)
+        victoria_day = date(2010, 5, 17)
+        self.assertIn(victoria_day, holidays)
+
+    def test_edinbirgh_autumn_holiday(self):
+        # Third Monday in September
+        holidays = self.cal.holidays_set(2018)
+        autumn_holiday = date(2018, 9, 17)
+        self.assertIn(autumn_holiday, holidays)
+
+
+class ScotlandElginTest(
+        SpringHolidaySecondMondayAprilTestMixin,
+        FairHolidayLastMondayJuneTestMixin,
+        LateSummerTestMixin,
+        AutumnHolidayThirdMondayOctoberTestMixin,
+        ScotlandTest):
+    cal_class = Elgin
+
+
+class ScotlandFalkirkTest(
+        GoodFridayTestMixin,
+        EasterMondayTestMixin,
+        FairHolidayFirstMondayJulyTestMixin,
+        BattleStirlingBridgeTestMixin,
+        ScotlandTest):
+    cal_class = Falkirk
+
+
+class ScotlandFifeTest(
+        VictoriaDayFirstMondayJuneTestMixin,
+        FairHolidayThirdMondayJulyTestMixin,
+        AutumnHolidayThirdMondayOctoberTestMixin,
+        SaintAndrewTestMixin,
+        ScotlandTest):
+    cal_class = Fife
+
+    def test_spring_holiday(self):
+        # Special computation rule, Fife has TWO spring holidays
+        holidays = self.cal.holidays_set(2018)
+        # First MON in April
+        self.assertIn(date(2018, 4, 2), holidays)
+        # First MON in June
+        self.assertIn(date(2018, 6, 4), holidays)
+
+
+class ScotlandGalashiels(VictoriaDayFirstMondayJuneTestMixin, ScotlandTest):
+    cal_class = Galashiels
+
+    def test_braw_lads_gathering(self):
+        # First friday in July
+        holidays = self.cal.holidays_set(2018)
+        braw_lads_gathering = date(2018, 7, 6)
+        self.assertIn(braw_lads_gathering, holidays)
+
+
+class ScotlandGlasgowTest(
+        EasterMondayTestMixin,
+        SpringHolidayLastMondayMayTestMixin,
+        FairHolidayThirdMondayJulyTestMixin,
+        AutumnHolidayLastMondaySeptemberTestMixin,
+        ScotlandTest):
+    cal_class = Glasgow
+
+
+class ScotlandHawickTest(ScotlandTest):
+    cal_class = Hawick
+
+    def test_common_riding(self):
+        # Friday after first monday in june & saturday
+        holidays = self.cal.holidays_set(2018)
+        common_riding_day1 = date(2018, 6, 8)
+        common_riding_day2 = date(2018, 6, 9)
+        self.assertIn(common_riding_day1, holidays)
+        self.assertIn(common_riding_day2, holidays)
+
+
+# https://www.inverclyde.gov.uk/council-and-government/council-public-holidays
+# These documents say that Spring Holidays happened:
+# * on April 11th 2016 (second monday of April)
+# * on April 24th 2017 (last monday April)
+# * on April 16th 2018 (3rd monday April)
+# * on April 29th 2019 (last monday April)
+# ...
+# I think I'm becoming crazy
+class ScotlandInverclydeTest(
+        GoodFridayTestMixin, EasterMondayTestMixin,
+        LateSummerTestMixin,
+        ScotlandTest):
+    cal_class = Inverclyde
+
+    def test_spring_holiday(self):
+        # Special computation rule, Fife has TWO spring holidays
+        holidays = self.cal.holidays_set(2018)
+        # Last MON in April
+        self.assertIn(date(2018, 4, 30), holidays)
+        # First MON in June
+        self.assertIn(date(2018, 6, 4), holidays)
+
+
+class ScotlandInvernessTest(
+        SpringHolidayFirstMondayAprilTestMixin,
+        FairHolidayFirstMondayJulyTestMixin,
+        AutumnHolidayFirstMondayOctoberTestMixin,
+        ScotlandTest):
+    cal_class = Inverness
+
+    def test_winter_february(self):
+        # First MON of February
+        holidays = self.cal.holidays_set(2018)
+        winter_february = date(2018, 2, 5)
+        self.assertIn(winter_february, holidays)
+
+    def test_winter_march(self):
+        # First MON of March
+        holidays = self.cal.holidays_set(2018)
+        winter_march = date(2018, 3, 5)
+        self.assertIn(winter_march, holidays)
+
+    def test_samhain_holiday(self):
+        # First MON of November
+        holidays = self.cal.holidays_set(2018)
+        samhain_holiday = date(2018, 11, 5)
+        self.assertIn(samhain_holiday, holidays)
+
+
+class ScotlandKilmarnockTest(
+        GoodFridayTestMixin, EasterMondayTestMixin,
+        AyrGoldCupTestMixin,
+        ScotlandTest):
+    cal_class = Kilmarnock
+
+
+class ScotlandLanarkTest(ScotlandTest):
+    cal_class = Lanark
+
+    def test_lanimer_day(self):
+        # Second THU in June
+        holidays = self.cal.holidays_set(2018)
+        lanimer_day = date(2018, 6, 14)
+        self.assertIn(lanimer_day, holidays)
+
+
+class ScotlandLinlithgowTest(ScotlandTest):
+    cal_class = Linlithgow
+
+    def test_linlithgow_marches(self):
+        # Linlithgow marches is on TUE after the 2nd THU in June
+        holidays = self.cal.holidays_set(2018)
+        linlithgow_marches = date(2018, 6, 19)
+        self.assertIn(linlithgow_marches, holidays)
+
+
+class ScotlandLochaberTest(ScotlandTest):
+    cal_class = Lochaber
+
+    def test_winter_holiday(self):
+        # Winter holiday is on last MON in March.
+        holidays = self.cal.holidays_set(2018)
+        winter_holiday = date(2018, 3, 26)
+        self.assertIn(winter_holiday, holidays)
+        # Not the 4th, the *last*
+        holidays = self.cal.holidays_set(2015)
+        winter_holiday = date(2015, 3, 30)
+        self.assertIn(winter_holiday, holidays)
+
+
+class ScotlandNorthLanarkshireTest(
+        EasterMondayTestMixin,
+        SpringHolidayLastMondayMayTestMixin,
+        FairHolidayThirdMondayJulyTestMixin,
+        AutumnHolidayLastMondaySeptemberTestMixin,
+        ScotlandTest):
+    cal_class = NorthLanarkshire
+
+
+class ScotlandPaisleyTest(
+        GoodFridayTestMixin, EasterMondayTestMixin,
+        VictoriaDayLastMondayMayTestMixin,
+        FairHolidayFirstMondayAugustTestMixin,
+        AutumnHolidayLastMondaySeptemberTestMixin,
+        ScotlandTest):
+    cal_class = Paisley
+
+
+class ScotlandPerthTest(
+        SpringHolidayFirstMondayAprilTestMixin,
+        VictoriaDayFourthMondayMayTestMixin,
+        BattleStirlingBridgeTestMixin,
+        AutumnHolidayFirstMondayOctoberTestMixin,
+        ScotlandTest):
+    cal_class = Perth
+
+
+class ScotlandScottishBordersTest(
+        SpringHolidayFirstMondayAprilTestMixin,
+        FairHolidayFourthFridayJulyTestMixin,
+        AutumnHolidaySecondMondayOctoberTestMixin,
+        SaintAndrewTestMixin,
+        ScotlandTest):
+    cal_class = ScottishBorders
+
+
+class ScotlandSouthLanarkshireTest(
+        GoodFridayTestMixin,
+        EasterMondayTestMixin,
+        SpringHolidayLastMondayMayTestMixin,
+        FairHolidayThirdMondayJulyTestMixin,
+        AutumnHolidayLastMondaySeptemberTestMixin,
+        ScotlandTest):
+    cal_class = SouthLanarkshire
+
+
+class ScotlandStirlingTest(
+        GoodFridayTestMixin,
+        EasterMondayTestMixin,
+        SpringHolidayTuesdayAfterFirstMondayMayTestMixin,
+        BattleStirlingBridgeTestMixin,
+        ScotlandTest):
+    cal_class = Stirling
+
+
+class ScotlandWestDunbartonshireTest(
+        GoodFridayTestMixin,
+        EasterMondayTestMixin,
+        AutumnHolidayLastMondaySeptemberTestMixin,
+        ScotlandTest):
+    cal_class = WestDunbartonshire

--- a/workalendar/tests/test_scotland.py
+++ b/workalendar/tests/test_scotland.py
@@ -1,5 +1,7 @@
 from datetime import date
-from unittest import TestCase
+from unittest import TestCase, skipIf
+import sys
+import warnings
 
 from workalendar.tests import GenericCalendarTest
 from workalendar.europe import (
@@ -9,6 +11,9 @@ from workalendar.europe import (
     Lanark, Linlithgow, Lochaber, NorthLanarkshire, Paisley, Perth,
     ScottishBorders, SouthLanarkshire, Stirling, WestDunbartonshire,
 )
+
+
+PY2 = sys.version_info[0] == 2
 
 
 class GoodFridayTestMixin(object):
@@ -269,6 +274,22 @@ class ScotlandTest(GenericCalendarTest):
     Some towns or cities don't necessarily observe it.
     """
     cal_class = Scotland
+
+    # For some reason, the Python 2 warnings module doesn't trigger a warning
+    # at each call of constructor ; skipping if we're in a Python2 env.
+    @skipIf(PY2, "Python 2 warnings unsupported")
+    def test_init_warning(self):
+        warnings.simplefilter("always")
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            # Trigger a warning.
+            self.cal_class()
+            # Verify some things
+            assert len(w) == 1
+            assert issubclass(w[-1].category, UserWarning)
+            assert "experimental" in str(w[-1].message)
+            # Back to normal filtering
+        warnings.simplefilter("ignore")
 
     def test_year_2018(self):
         holidays = self.cal.holidays_set(2018)


### PR DESCRIPTION
closes #31 

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Docstrings for the Calendar class and specific methods.
- [x] ~~Use the ``workalendar.registry.iso_register`` decorator to register your new calendar using ISO codes (optional).~~ looks like Scotland is attached to the GB, doesn't have a proper ISO code.
- [x] Calendar country / label added to the README.rst file,
- [x] Changelog amended
