### PR TITLE
v4.1.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## master (unreleased)
+## v4.1.0 (2019-02-07)
 
 ### New calendars
 
@@ -10,11 +10,11 @@
 
 ### Bugfixes
 
-- Fixed United Kingdom bank holiday for 2002 and 2012 (#315).
+- Fixed United Kingdom bank holiday for 2002 and 2012, thx @ludsoft (#315).
 - Fix a small flake8 issue with wrong indentation (#319).
 - Fix Russia "Day of Unity" date, set to November 4th, thx @alexitkes for the bug report (#317).
 
-## 4.0.0 (2019-01-24)
+## v4.0.0 (2019-01-24)
 
 - Solved the incompatibility between `pandas` latest version and Python 3.4. Upgraded travis distro to Xenial/16.04 LTS (#307).
 - Added instructions about the usage of the `iso_register` decorator in the pull-request template (#309).

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## master (unreleased)
+
+Nothing here yet.
+
 ## v4.1.0 (2019-02-07)
 
 ### New calendars

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ REQUIREMENTS = [
     'pyluach',
     'setuptools>=1.0',
 ]
-version = '4.1.0'
+version = '4.2.0.dev0'
 __VERSION__ = version
 
 params = dict(

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ REQUIREMENTS = [
     'pyluach',
     'setuptools>=1.0',
 ]
-version = '4.1.0.dev0'
+version = '4.1.0'
 __VERSION__ = version
 
 params = dict(


### PR DESCRIPTION
**New calendars**

*WARNING* Scotland (sub)calendars are highly experimental and because of their very puzzling rules, may be false. Please use them with care.

- Added Scotland calendars, i.e. Scotland, Aberdeen, Angus, Arbroath, Ayr, Carnoustie & Monifieth, Clydebank, Dumfries & Galloway, Dundee, East Dunbartonshire, Edinburgh, Elgin, Falkirk, Fife, Galashiels, Glasgow, Hawick, Inverclyde, Inverness, Kilmarnock, Lochaber, Monifieth, North Lanarkshire, Paisley, Perth, Scottish Borders, South Lanarkshire, Stirling, and West Dunbartonshire (#31).

**Bugfixes**

- Fixed United Kingdom bank holiday for 2002 and 2012, thx @ludsoft (#315).
- Fix a small flake8 issue with wrong indentation (#319).
- Fix Russia "Day of Unity" date, set to November 4th, thx @alexitkes for the bug report (#317).
