### PR TITLE
Added American Samoa (US territory)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Added the American Samoa territory to the USA calendars (#218).
 
 ## v4.1.0 (2019-02-07)
 

--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ America
 * Mexico
 * Panama
 * Paraguay
-* United States of America (including state holidays)
+* United States of America (including State holidays for all the 50 States, and American Samoa)
 * Canada (including provincial and territory holidays)
 
 Asia

--- a/workalendar/tests/test_usa.py
+++ b/workalendar/tests/test_usa.py
@@ -12,7 +12,9 @@ from workalendar.usa import (
     Montana, Nebraska, Nevada, NewHampshire, NewJersey, NewMexico, NewYork,
     NorthCarolina, NorthDakota, Ohio, Oklahoma, Oregon, Pennsylvania,
     RhodeIsland, SouthCarolina, SouthDakota, Tennessee, TexasBase, Texas,
-    Utah, Vermont, Virginia, Washington, WestVirginia, Wisconsin, Wyoming
+    Utah, Vermont, Virginia, Washington, WestVirginia, Wisconsin, Wyoming,
+    # Not a state, but an American territory
+    AmericanSamoa,
 )
 
 
@@ -1334,3 +1336,20 @@ class WyomingTest(UnitedStatesTest):
             label,
             "Martin Luther King, Jr. / Wyoming Equality Day"
         )
+
+
+class AmericanSamoaTest(UnitedStatesTest):
+    cal_class = AmericanSamoa
+
+    def test_family_day(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 12, 26), holidays)  # Family Day
+
+    def test_flag_day(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 4, 17), holidays)  # Flag Day
+
+    def test_family_day_label(self):
+        holidays = self.cal.holidays(2019)
+        holidays_dict = dict(holidays)
+        self.assertEqual(holidays_dict[date(2019, 12, 26)], "Family Day")

--- a/workalendar/usa/__init__.py
+++ b/workalendar/usa/__init__.py
@@ -56,7 +56,6 @@ from .west_virginia import WestVirginia
 from .wisconsin import Wisconsin
 from .wyoming import Wyoming
 
-NONE, NEAREST_WEEKDAY, MONDAY = range(3)
 
 __all__ = [
     'UnitedStates',  # Generic federal calendar

--- a/workalendar/usa/__init__.py
+++ b/workalendar/usa/__init__.py
@@ -55,6 +55,8 @@ from .washington import Washington
 from .west_virginia import WestVirginia
 from .wisconsin import Wisconsin
 from .wyoming import Wyoming
+# American Territory
+from .american_samoa import AmericanSamoa
 
 
 __all__ = [
@@ -112,4 +114,6 @@ __all__ = [
     'WestVirginia',
     'Wisconsin',
     'Wyoming',
+    # American territory
+    'AmericanSamoa',
 ]

--- a/workalendar/usa/american_samoa.py
+++ b/workalendar/usa/american_samoa.py
@@ -1,0 +1,29 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from datetime import date
+
+from .core import UnitedStates
+from ..registry import iso_register
+
+
+@iso_register('US-AS')
+class AmericanSamoa(UnitedStates):
+    "American Samoa"
+    include_boxing_day = True
+    boxing_day_label = "Family Day"
+
+    def get_flag_day(self, year):
+        """
+        Flag day is on April 17th
+        """
+        return (
+            date(year, 4, 17),
+            "Flag Day"
+        )
+
+    def get_variable_days(self, year):
+        days = super(AmericanSamoa, self).get_variable_days(year)
+        days.extend([
+            self.get_flag_day(year),
+        ])
+        return days


### PR DESCRIPTION
refs #218

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Docstrings for the Calendar class and specific methods.
- [x] Use the ``workalendar.registry.iso_register`` decorator to register your new calendar using ISO codes (optional).
- [x] Calendar country / label added to the README.rst file,
- [x] Changelog amended with a mention like: "Added ``<country>`` by ``@pseudo`` (#)"
