### PR TITLE
Added Guam (Us Territory)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,10 @@
 
 ## master (unreleased)
 
-- Added the American Samoa territory to the USA calendars (#218).
-- Added Chicago, Illinois calendar (#220).
+- Added several US territories and other specific calendars:
+  - American Samoa territory (#218).
+  - Chicago, Illinois (#220).
+  - Guam territory (#219).
 
 ## v4.1.0 (2019-02-07)
 

--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,7 @@ America
   * State holidays for all the 50 States
   * American Samoa
   * Chicago, Illinois
+  * Guam
 * Canada (including provincial and territory holidays)
 
 Asia

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -372,6 +372,7 @@ class ChristianMixin(Calendar):
     include_easter_sunday = False
     include_all_saints = False
     include_immaculate_conception = False
+    immaculate_conception_label = "Immaculate Conception"
     include_christmas = True
     include_christmas_eve = False
     include_ascension = False
@@ -486,7 +487,7 @@ class ChristianMixin(Calendar):
         if self.include_all_souls:
             days.append((date(year, 11, 2), "All Souls Day"))
         if self.include_immaculate_conception:
-            days.append((date(year, 12, 8), "Immaculate Conception"))
+            days.append((date(year, 12, 8), self.immaculate_conception_label))
         if self.include_christmas:
             days.append((date(year, 12, 25), "Christmas Day"))
         if self.include_christmas_eve:

--- a/workalendar/tests/test_usa.py
+++ b/workalendar/tests/test_usa.py
@@ -14,7 +14,7 @@ from workalendar.usa import (
     RhodeIsland, SouthCarolina, SouthDakota, Tennessee, TexasBase, Texas,
     Utah, Vermont, Virginia, Washington, WestVirginia, Wisconsin, Wyoming,
     # Other territories, cities...
-    AmericanSamoa, ChicagoIllinois,
+    AmericanSamoa, ChicagoIllinois, Guam,
 )
 
 
@@ -1381,3 +1381,31 @@ class AmericanSamoaTest(UnitedStatesTest):
         holidays = self.cal.holidays(2019)
         holidays_dict = dict(holidays)
         self.assertEqual(holidays_dict[date(2019, 12, 26)], "Family Day")
+
+
+class Guam(UnitedStatesTest):
+    cal_class = Guam
+
+    def test_state_year_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        # Guam History and Chamorro Heritage Day
+        self.assertIn(date(2019, 3, 7), holidays)
+        self.assertIn(date(2019, 7, 21), holidays)  # Liberation Day
+        self.assertIn(date(2019, 11, 2), holidays)  # All Souls Day
+        self.assertIn(date(2019, 12, 8), holidays)  # Lady of Camarin Day
+
+    def test_state_year_2018(self):
+        holidays = self.cal.holidays_set(2020)
+        # Guam History and Chamorro Heritage Day
+        self.assertIn(date(2020, 3, 7), holidays)
+        self.assertIn(date(2020, 7, 21), holidays)  # Liberation Day
+        self.assertIn(date(2020, 11, 2), holidays)  # All Souls Day
+        self.assertIn(date(2020, 12, 8), holidays)  # Lady of Camarin Day
+
+    def test_lady_of_camarin_label(self):
+        holidays = self.cal.holidays(2019)
+        holidays_dict = dict(holidays)
+        self.assertEqual(
+            holidays_dict[date(2019, 12, 8)],
+            "Lady of Camarin Day"
+        )

--- a/workalendar/usa/__init__.py
+++ b/workalendar/usa/__init__.py
@@ -55,8 +55,9 @@ from .washington import Washington
 from .west_virginia import WestVirginia
 from .wisconsin import Wisconsin
 from .wyoming import Wyoming
-# American Territory
+# Non-states territories and areas
 from .american_samoa import AmericanSamoa
+from .guam import Guam
 
 
 __all__ = [
@@ -114,6 +115,7 @@ __all__ = [
     'WestVirginia',
     'Wisconsin',
     'Wyoming',
-    # American territory
+    # Non-State territories
     'AmericanSamoa',
+    'Guam',
 ]

--- a/workalendar/usa/guam.py
+++ b/workalendar/usa/guam.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from .core import UnitedStates
+from ..registry import iso_register
+
+
+@iso_register('US-GU')
+class Guam(UnitedStates):
+    """Guam"""
+    FIXED_HOLIDAYS = UnitedStates.FIXED_HOLIDAYS + (
+        (3, 7, 'Guam History and Chamorro Heritage Day'),
+        (7, 21, 'Liberation Day'),
+    )
+    include_all_souls = True
+    include_immaculate_conception = True
+    immaculate_conception_label = "Lady of Camarin Day"


### PR DESCRIPTION
refs #219

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Docstrings for the Calendar class and specific methods.
- [x] Use the ``workalendar.registry.iso_register`` decorator to register your new calendar using ISO codes (optional).
- [x] Calendar country / label added to the README.rst file,
- [x] Changelog amended with a mention like: "Added ``<country>`` by ``@pseudo`` (#)"
