### PR TITLE
Added Suffolk County, Massachusetts calendar

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
   - American Samoa territory (#218).
   - Chicago, Illinois (#220).
   - Guam territory (#219).
+  - Suffolk County, Massachusetts (#222).
 
 ## v4.1.0 (2019-02-07)
 

--- a/README.rst
+++ b/README.rst
@@ -127,6 +127,7 @@ America
   * American Samoa
   * Chicago, Illinois
   * Guam
+  * Suffolk County, Massachusetts
 * Canada (including provincial and territory holidays)
 
 Asia

--- a/workalendar/tests/test_usa.py
+++ b/workalendar/tests/test_usa.py
@@ -14,7 +14,7 @@ from workalendar.usa import (
     RhodeIsland, SouthCarolina, SouthDakota, Tennessee, TexasBase, Texas,
     Utah, Vermont, Virginia, Washington, WestVirginia, Wisconsin, Wyoming,
     # Other territories, cities...
-    AmericanSamoa, ChicagoIllinois, Guam,
+    AmericanSamoa, ChicagoIllinois, Guam, SuffolkCountyMassachusetts,
 )
 
 
@@ -802,6 +802,20 @@ class MassachusettsTest(UnitedStatesTest):
     def test_state_year_2015(self):
         holidays = self.cal.holidays_set(2015)
         self.assertIn(date(2015, 4, 20), holidays)  # Patriot's day
+
+
+class SuffolkCountyMassachusettsTest(MassachusettsTest):
+    cal_class = SuffolkCountyMassachusetts
+
+    def test_county_year_2018(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 3, 17), holidays)  # Evacuation Day
+        self.assertIn(date(2018, 6, 17), holidays)  # Bunker Hill Day
+
+    def test_county_year_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 3, 17), holidays)  # Evacuation Day
+        self.assertIn(date(2019, 6, 17), holidays)  # Bunker Hill Day
 
 
 class MichiganTest(NoColumbus, ElectionDayEvenYears, UnitedStatesTest):

--- a/workalendar/usa/__init__.py
+++ b/workalendar/usa/__init__.py
@@ -25,7 +25,7 @@ from .kentucky import Kentucky
 from .louisiana import Louisiana
 from .maine import Maine
 from .maryland import Maryland
-from .massachusetts import Massachusetts
+from .massachusetts import Massachusetts, SuffolkCountyMassachusetts
 from .michigan import Michigan
 from .minnesota import Minnesota
 from .mississippi import Mississippi
@@ -84,7 +84,7 @@ __all__ = [
     'Louisiana',
     'Maine',
     'Maryland',
-    'Massachusetts',
+    'Massachusetts', 'SuffolkCountyMassachusetts',
     'Michigan',
     'Minnesota',
     'Mississippi',

--- a/workalendar/usa/massachusetts.py
+++ b/workalendar/usa/massachusetts.py
@@ -10,3 +10,11 @@ from ..registry import iso_register
 class Massachusetts(UnitedStates):
     """Massachusetts"""
     include_patriots_day = True
+
+
+class SuffolkCountyMassachusetts(Massachusetts):
+    """Suffolk County, Massachusetts"""
+    FIXED_HOLIDAYS = UnitedStates.FIXED_HOLIDAYS + (
+        (3, 17, 'Evacuation Day'),
+        (6, 17, 'Bunker Hill Day'),
+    )


### PR DESCRIPTION
closes #222


- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Docstrings for the Calendar class and specific methods.
- [x] ~~Use the ``workalendar.registry.iso_register`` decorator to register your new calendar using ISO codes (optional).~~ there's no such thing as a ISO code for US counties.
- [x] Calendar country / label added to the README.rst file,
- [x] Changelog amended with a mention like: "Added ``<country>`` by ``@pseudo`` (#)"
