### PR TITLE
v4.2.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,13 +1,15 @@
 # CHANGELOG
 
-## master (unreleased)
+## v4.2.0 (2019-02-21)
+
+### New calendars
 
 - Added several US territories and other specific calendars:
   - American Samoa territory (#218).
   - Chicago, Illinois (#220).
   - Guam territory (#219).
   - Suffolk County, Massachusetts (#222).
-  - Cayman Islands, British Overseas Territory (#328)
+- Added Cayman Islands, British Overseas Territory (#328)
 
 ## v4.1.0 (2019-02-07)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## master (unreleased)
+
+Nothing here yet.
+
 ## v4.2.0 (2019-02-21)
 
 ### New calendars

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ REQUIREMENTS = [
     'pyluach',
     'setuptools>=1.0',
 ]
-version = '4.2.0.dev0'
+version = '4.2.0'
 __VERSION__ = version
 
 params = dict(

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ REQUIREMENTS = [
     'pyluach',
     'setuptools>=1.0',
 ]
-version = '4.2.0'
+version = '4.3.0.dev0'
 __VERSION__ = version
 
 params = dict(


### PR DESCRIPTION
## New calendars

- Added several US territories and other specific calendars:
  - American Samoa territory (#218).
  - Chicago, Illinois (#220).
  - Guam territory (#219).
  - Suffolk County, Massachusetts (#222).
- Added Cayman Islands, British Overseas Territory (#328)

TODO

- [x] Changelog with date
- [x] setup.py
- [x] "back to dev" commit with 4.3.0.dev0
