### PR TITLE
Add Barbados Calendar.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - Added isolated tests for shifting mechanics in USA calendars - previously untested (#335).
+- Added Barbados by @ludsoft.
 
 ## v4.2.0 (2019-02-21)
 

--- a/README.rst
+++ b/README.rst
@@ -130,6 +130,7 @@ America
   * Guam
   * Suffolk County, Massachusetts
 * Canada (including provincial and territory holidays)
+* Barbados
 
 Asia
 ----

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -20,6 +20,7 @@ from .colombia import Colombia
 from .mexico import Mexico
 from .panama import Panama
 from .paraguay import Paraguay
+from .barbados import Barbados
 
 
 __all__ = (
@@ -77,4 +78,5 @@ __all__ = (
     'Mexico',
     'Panama',
     'Paraguay',
+    'Barbados',
 )

--- a/workalendar/america/barbados.py
+++ b/workalendar/america/barbados.py
@@ -1,14 +1,14 @@
 from __future__ import absolute_import, division, print_function
-from datetime import date
+from datetime import date, timedelta
 from dateutil import easter
 
 from ..core import WesternCalendar, ChristianMixin
-from ..core import Calendar, SUN, MON
+from ..core import SUN, MON
 from ..registry import iso_register
 
 
 @iso_register("BB")
-class Barbados(ChristianMixin, WesternCalendar):
+class Barbados(WesternCalendar, ChristianMixin):
     "Barbados"
 
     include_good_friday = True
@@ -16,8 +16,6 @@ class Barbados(ChristianMixin, WesternCalendar):
     include_easter_monday = True
     include_whit_monday = True
     include_boxing_day = True
-    shift_sunday_holidays = True
-    EASTER_METHOD = easter.EASTER_WESTERN
 
     # All holiday are shifted if on a Sunday
     almost_fixed_holidays = WesternCalendar.FIXED_HOLIDAYS + (
@@ -45,16 +43,16 @@ class Barbados(ChristianMixin, WesternCalendar):
         return days
 
     def get_variable_days(self, year):
-        ch_days = super(Barbados, self).get_variable_days(year)
+        christian_days = super(Barbados, self).get_variable_days(year)
         almost_fixed = self.get_almost_fixed_holidays(year)
-        all_days = ch_days + almost_fixed
+        all_days = christian_days + almost_fixed
         all_days.append(self.get_kadooment_day(year))
         days = []
         for day in all_days:
             if day[0].weekday() == SUN:
                 days.append(
-                    (Calendar.get_first_weekday_after(day[0], MON), day[1])
+                    (day[0] + timedelta(days=1),
+                     "%s %s" % (day[1], "(shifted)"))
                 )
-            else:
-                days.append(day)
+            days.append(day)
         return days

--- a/workalendar/america/barbados.py
+++ b/workalendar/america/barbados.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 from datetime import date, timedelta
-from dateutil import easter
 
 from ..core import WesternCalendar, ChristianMixin
 from ..core import SUN, MON
@@ -43,9 +42,9 @@ class Barbados(WesternCalendar, ChristianMixin):
         return days
 
     def get_variable_days(self, year):
-        christian_days = super(Barbados, self).get_variable_days(year)
+        western_days = super(Barbados, self).get_variable_days(year)
         almost_fixed = self.get_almost_fixed_holidays(year)
-        all_days = christian_days + almost_fixed
+        all_days = western_days + almost_fixed
         all_days.append(self.get_kadooment_day(year))
         days = []
         for day in all_days:

--- a/workalendar/america/barbados.py
+++ b/workalendar/america/barbados.py
@@ -1,0 +1,60 @@
+from __future__ import absolute_import, division, print_function
+from datetime import date
+from dateutil import easter
+
+from ..core import WesternCalendar, ChristianMixin
+from ..core import Calendar, SUN, MON
+from ..registry import iso_register
+
+
+@iso_register("BB")
+class Barbados(ChristianMixin, WesternCalendar):
+    "Barbados"
+
+    include_good_friday = True
+    include_easter_sunday = True
+    include_easter_monday = True
+    include_whit_monday = True
+    include_boxing_day = True
+    shift_sunday_holidays = True
+    EASTER_METHOD = easter.EASTER_WESTERN
+
+    # All holiday are shifted if on a Sunday
+    almost_fixed_holidays = WesternCalendar.FIXED_HOLIDAYS + (
+        (1, 21, "Errol Barrow Day"),
+        (4, 28, "National Heroes Day"),
+        (5, 1, "Labour Day"),
+        (8, 1, "Emancipation Day"),
+        (11, 30, "Independance Day"),
+    )
+
+    def get_kadooment_day(self, year):
+        """First Monday of August.
+        """
+        return (Barbados.get_nth_weekday_in_month(year, 8, MON),
+                "Kadooment Day")
+
+    def get_almost_fixed_holidays(self, year):
+        """
+        Return the fixed days according to the almost_fixed_holidays
+        class property. All holidays are shifted to Monday if on a Sunday
+        """
+        days = []
+        for month, day, label in self.almost_fixed_holidays:
+            days.append((date(year, month, day), label))
+        return days
+
+    def get_variable_days(self, year):
+        ch_days = super(Barbados, self).get_variable_days(year)
+        almost_fixed = self.get_almost_fixed_holidays(year)
+        all_days = ch_days + almost_fixed
+        all_days.append(self.get_kadooment_day(year))
+        days = []
+        for day in all_days:
+            if day[0].weekday() == SUN:
+                days.append(
+                    (Calendar.get_first_weekday_after(day[0], MON), day[1])
+                )
+            else:
+                days.append(day)
+        return days

--- a/workalendar/tests/test_america.py
+++ b/workalendar/tests/test_america.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import date
 from workalendar.tests import GenericCalendarTest
-from workalendar.america import Colombia
+from workalendar.america import Colombia, Barbados
 from workalendar.america import Mexico, Chile, Panama, Paraguay
 
 
@@ -149,3 +149,52 @@ class ParaguayTest(GenericCalendarTest):
         # Boqueron Battle Victory Day: moved to October 2nd for 2017
         self.assertNotIn(date(2017, 9, 29), holidays)
         self.assertIn(date(2017, 10, 2), holidays)
+
+
+class BarbadosTest(GenericCalendarTest):
+    cal_class = Barbados
+
+    def test_holidays_2009(self):
+        holidays = self.cal.holidays_set(2009)
+        self.assertIn(date(2009, 1, 1), holidays)
+        self.assertIn(date(2009, 1, 21), holidays)  # Errol Barrow Day
+        self.assertIn(date(2009, 4, 10), holidays)  # Good Friday
+        self.assertIn(date(2009, 4, 13), holidays)  # Easter Monday
+        self.assertIn(date(2009, 4, 28), holidays)  # National Hearos Day
+        self.assertIn(date(2009, 5, 1), holidays)  # Labour Day
+        self.assertIn(date(2009, 6, 1), holidays)  # Whit Monday
+        self.assertIn(date(2009, 8, 1), holidays)  # Emancipation Day
+        self.assertIn(date(2009, 8, 3), holidays)  # Kabooment Day
+        self.assertIn(date(2009, 11, 30), holidays)  # Independant Day
+        self.assertIn(date(2009, 12, 25), holidays)  # Christmas Day
+        self.assertIn(date(2009, 12, 26), holidays)  # Boxing Day
+
+    def test_holidays_2018(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 1, 1), holidays)
+        self.assertIn(date(2018, 1, 22), holidays)  # Errol Barrow Day
+        self.assertIn(date(2018, 3, 30), holidays)  # Good Friday
+        self.assertIn(date(2018, 4, 2), holidays)  # Easter Monday
+        self.assertIn(date(2018, 4, 28), holidays)  # National Hearos Day
+        self.assertIn(date(2018, 5, 1), holidays)  # Labour Day
+        self.assertIn(date(2018, 5, 21), holidays)  # Whit Monday
+        self.assertIn(date(2018, 8, 1), holidays)  # Emancipation Day
+        self.assertIn(date(2018, 8, 6), holidays)  # Kabooment Day
+        self.assertIn(date(2018, 11, 30), holidays)  # Independant Day
+        self.assertIn(date(2018, 12, 25), holidays)  # Christmas Day
+        self.assertIn(date(2018, 12, 26), holidays)  # Boxing Day
+
+    def test_holidays_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 1, 1), holidays)
+        self.assertIn(date(2019, 1, 21), holidays)  # Errol Barrow Day
+        self.assertIn(date(2019, 4, 19), holidays)  # Good Friday
+        self.assertIn(date(2019, 4, 22), holidays)  # Easter Monday
+        self.assertIn(date(2019, 4, 29), holidays)  # National Hearos Day
+        self.assertIn(date(2019, 5, 1), holidays)  # Labour Day
+        self.assertIn(date(2019, 6, 10), holidays)  # Whit Monday
+        self.assertIn(date(2019, 8, 1), holidays)  # Emancipation Day
+        self.assertIn(date(2019, 8, 5), holidays)  # Kabooment Day
+        self.assertIn(date(2019, 11, 30), holidays)  # Independant Day
+        self.assertIn(date(2019, 12, 25), holidays)  # Christmas Day
+        self.assertIn(date(2019, 12, 26), holidays)  # Boxing Day


### PR DESCRIPTION
refs #

<!-- if your contribution is a new calendar -->

For information, read and make sure you're okay with the [CONTRIBUTING document](https://github.com/novafloss/workalendar/blob/master/CONTRIBUTING.rst#adding-new-calendars).

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Docstrings for the Calendar class and specific methods.
- [x] Use the ``workalendar.registry.iso_register`` decorator to register your new calendar using ISO codes (optional).
- [x] Calendar country / label added to the README.rst file,
- [x] Changelog amended with a mention like: "Added ``<country>`` by ``@pseudo`` (#)"

I've not found much of official sources, here are examples of two years on the official websites:
https://web.archive.org/web/20090806030650/http://www.barbados.gov.bb/bdospublichol2.htm
https://labour.gov.bb/wp-content/uploads/PDF/Public-Holidays-for-the-Year-2019.pdf