### PR TITLE
Added several one-off public holidays to UK calendar.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Added isolated tests for shifting mechanics in USA calendars - previously untested (#335).
 - Added Barbados by @ludsoft.
+- Added several one-off public holidays to UK calendar (#366).
 
 ## v4.2.0 (2019-02-21)
 

--- a/workalendar/europe/united_kingdom.py
+++ b/workalendar/europe/united_kingdom.py
@@ -16,7 +16,12 @@ class UnitedKingdom(WesternCalendar, ChristianMixin):
     include_boxing_day = True
     shift_new_years_day = True
     non_computable_holiday_dict = {
+        1973: [(date(1973, 11, 14), "Royal wedding"), ],
+        1977: [(date(1977, 6, 7), "Queen’s Silver Jubilee"), ],
+        1981: [(date(1981, 7, 29), "Royal wedding"), ],
+        1999: [(date(1999, 12, 31), "New Year's Eve"), ],
         2002: [(date(2002, 6, 3), "Queen’s Golden Jubilee"), ],
+        2011: [(date(2011, 4, 29), "Royal Wedding"), ],
         2012: [(date(2012, 6, 5), "Queen’s Diamond Jubilee"), ],
     }
 
@@ -29,6 +34,8 @@ class UnitedKingdom(WesternCalendar, ChristianMixin):
     def get_spring_bank_holiday(self, year):
         if year == 2012:
             spring_bank_holiday = date(2012, 6, 4)
+        elif year == 1977:
+            spring_bank_holiday = date(1977, 6, 6)
         elif year == 2002:
             spring_bank_holiday = date(2002, 6, 4)
         else:

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -815,17 +815,22 @@ class Russia(GenericCalendarTest):
 class UnitedKingdomTest(GenericCalendarTest):
     cal_class = UnitedKingdom
 
-    def test_year_2013(self):
-        holidays = self.cal.holidays_set(2013)
-        self.assertIn(date(2013, 1, 1), holidays)  # new year day
-        self.assertIn(date(2013, 3, 29), holidays)  # good friday
-        self.assertIn(date(2013, 3, 31), holidays)  # easter sunday
-        self.assertIn(date(2013, 4, 1), holidays)  # easter monday
-        self.assertIn(date(2013, 5, 6), holidays)  # Early May Bank Holiday
-        self.assertIn(date(2013, 5, 27), holidays)  # Spring Bank Holiday
-        self.assertIn(date(2013, 8, 26), holidays)  # Late Summer Bank Holiday
-        self.assertIn(date(2013, 12, 25), holidays)  # Christmas
-        self.assertIn(date(2013, 12, 26), holidays)  # Boxing Day
+    def test_year_1973(self):
+        holidays = self.cal.holidays_set(1973)
+        self.assertIn(date(1973, 11, 14), holidays)  # royal wedding
+
+    def test_year_1977(self):
+        holidays = self.cal.holidays_set(1977)
+        self.assertIn(date(1977, 6, 6), holidays)  # Early May Bank Holiday
+        self.assertIn(date(1977, 6, 7), holidays)  # queen's silver jubilee
+
+    def test_year_1981(self):
+        holidays = self.cal.holidays_set(1981)
+        self.assertIn(date(1981, 7, 29), holidays)  # royal wedding
+
+    def test_year_1999(self):
+        holidays = self.cal.holidays_set(1999)
+        self.assertIn(date(1999, 12, 31), holidays)  # new year's eve
 
     def test_year_2002(self):
         holidays = self.cal.holidays_set(2002)
@@ -840,6 +845,10 @@ class UnitedKingdomTest(GenericCalendarTest):
         self.assertIn(date(2002, 12, 25), holidays)  # Christmas
         self.assertIn(date(2002, 12, 26), holidays)  # Boxing Day
 
+    def test_year_2011(self):
+        holidays = self.cal.holidays_set(2011)
+        self.assertIn(date(2011, 4, 29), holidays)  # royal wedding
+
     def test_year_2012(self):
         holidays = self.cal.holidays_set(2012)
         self.assertIn(date(2012, 1, 1), holidays)  # new year day
@@ -853,6 +862,18 @@ class UnitedKingdomTest(GenericCalendarTest):
         self.assertIn(date(2012, 8, 27), holidays)  # Late Summer Bank Holiday
         self.assertIn(date(2012, 12, 25), holidays)  # Christmas
         self.assertIn(date(2012, 12, 26), holidays)  # Boxing Day
+
+    def test_year_2013(self):
+        holidays = self.cal.holidays_set(2013)
+        self.assertIn(date(2013, 1, 1), holidays)  # new year day
+        self.assertIn(date(2013, 3, 29), holidays)  # good friday
+        self.assertIn(date(2013, 3, 31), holidays)  # easter sunday
+        self.assertIn(date(2013, 4, 1), holidays)  # easter monday
+        self.assertIn(date(2013, 5, 6), holidays)  # Early May Bank Holiday
+        self.assertIn(date(2013, 5, 27), holidays)  # Spring Bank Holiday
+        self.assertIn(date(2013, 8, 26), holidays)  # Late Summer Bank Holiday
+        self.assertIn(date(2013, 12, 25), holidays)  # Christmas
+        self.assertIn(date(2013, 12, 26), holidays)  # Boxing Day
 
     def test_shift_2012(self):
         holidays = self.cal.holidays_set(2012)


### PR DESCRIPTION
This PR is a follow-up to ticket #336 - re. a public holiday that was not in workcalendar. When I did a bit more research, I found several one-off public holidays in the UK that were missed (links are to trustworthy sources):

* 1973: [Royal wedding](http://news.bbc.co.uk/onthisday/hi/dates/stories/november/14/newsid_2519000/2519003.stm) 
* 1977: [Queen's Silver Jubilee](https://api.parliament.uk/historic-hansard/written-answers/1977/jan/19/queens-silver-jubilee)
* 1981: [Royal Wedding](http://news.bbc.co.uk/onthisday/hi/dates/stories/july/29/newsid_2494000/2494949.stm)
* 1999: [extra holiday for the millenium](http://news.bbc.co.uk/2/hi/uk_news/376063.stm)
* 2011: [Royal wedding](https://www.bbc.com/news/uk-11818049)

Concerning the Queen's Silver Jubilee, the document that I linked to - a transcript of discussions in the UK Parliament - also mentions:
* that the date of the Spring Bank Holiday for that year was changed - I've updated workcalendar.
* that the public holiday in Scotland "...will take place on dates arranged by the District Councils". I could not find more detailed information on this subject, so for now Scotland has the same date as the UK - although it might be wrong.
