### PR TITLE
update China Labour Day 2019 based on latest official notification.

### DIFF
--- a/workalendar/asia/china.py
+++ b/workalendar/asia/china.py
@@ -39,7 +39,7 @@ workdays = {
         {
             'Spring Festival Shift': [(2, 2), (2, 3)],
             'National Day Shift': [(9, 29), (10, 12)],
-            'Labour Day Holiday Shift': [(5, 5)]
+            'Labour Day Holiday Shift': [(4, 28), (5, 5)]
         },
 }
 

--- a/workalendar/asia/china.py
+++ b/workalendar/asia/china.py
@@ -31,7 +31,7 @@ workdays = {
         {
             'Spring Festival Shift': [(2, 11), (2, 24)],
             'Ching Ming Festival Shift': [(4, 8)],
-            'Labour Day Holiday Shift': [(4, 28), (5, 5)],
+            'Labour Day Holiday Shift': [(4, 28)],
             'National Day Shift': [(9, 29), (9, 30)],
             'New year Shift': [(12, 29)]
         },
@@ -39,6 +39,7 @@ workdays = {
         {
             'Spring Festival Shift': [(2, 2), (2, 3)],
             'National Day Shift': [(9, 29), (10, 12)],
+            'Labour Day Holiday Shift': [(5, 5)]
         },
 }
 

--- a/workalendar/asia/china.py
+++ b/workalendar/asia/china.py
@@ -20,7 +20,7 @@ holidays = {
     2019:
         {
             'Ching Ming Festival': [(4, 5)],
-            'Labour Day Holiday': [(5, 1)],
+            'Labour Day Holiday': [(5, 1), (5, 2), (5, 3)],
             'Dragon Boat Festival': [(6, 7)],
             'Mid-Autumn Festival': [(9, 13)]
         },
@@ -31,7 +31,7 @@ workdays = {
         {
             'Spring Festival Shift': [(2, 11), (2, 24)],
             'Ching Ming Festival Shift': [(4, 8)],
-            'Labour Day Holiday Shift': [(4, 28)],
+            'Labour Day Holiday Shift': [(4, 28), (5, 5)],
             'National Day Shift': [(9, 29), (9, 30)],
             'New year Shift': [(12, 29)]
         },

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -34,7 +34,7 @@ class ChinaTest(GenericCalendarTest):
         self.assertIn(date(2019, 5, 1), holidays)   # Labour Day Holiday
         self.assertIn(date(2019, 5, 2), holidays)   # Labour Day Holiday
         self.assertIn(date(2019, 5, 3), holidays)   # Labour Day Holiday
-        
+
         # Labour Day Holiday Shift
         self.assertTrue(self.cal.is_working_day(date(2019, 5, 5)))
 

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -29,6 +29,13 @@ class ChinaTest(GenericCalendarTest):
         self.assertIn(date(2018, 12, 30), holidays)  # New year
         self.assertIn(date(2018, 12, 31), holidays)  # New year
 
+    def test_year_2019(self):
+        holidays = self.cal.holidays_set(2019)      # Labour Day Holiday
+        self.assertIn(date(2019, 5, 1), holidays)   # Labour Day Holiday
+        self.assertIn(date(2019, 5, 2), holidays)   # Labour Day Holiday
+        self.assertIn(date(2019, 5, 3), holidays)   # Labour Day Holiday
+        self.assertTrue(self.cal.is_working_day(date(2019, 5, 5)))  # Labour Day Holiday Shift
+
 
 class HongKongTest(GenericCalendarTest):
 

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -34,7 +34,9 @@ class ChinaTest(GenericCalendarTest):
         self.assertIn(date(2019, 5, 1), holidays)   # Labour Day Holiday
         self.assertIn(date(2019, 5, 2), holidays)   # Labour Day Holiday
         self.assertIn(date(2019, 5, 3), holidays)   # Labour Day Holiday
-        self.assertTrue(self.cal.is_working_day(date(2019, 5, 5)))  # Labour Day Holiday Shift
+        
+        # Labour Day Holiday Shift
+        self.assertTrue(self.cal.is_working_day(date(2019, 5, 5)))
 
 
 class HongKongTest(GenericCalendarTest):

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -36,6 +36,7 @@ class ChinaTest(GenericCalendarTest):
         self.assertIn(date(2019, 5, 3), holidays)   # Labour Day Holiday
 
         # Labour Day Holiday Shift
+        self.assertTrue(self.cal.is_working_day(date(2019, 4, 28)))
         self.assertTrue(self.cal.is_working_day(date(2019, 5, 5)))
 
 


### PR DESCRIPTION
Update China Labour Day holiday plans of 2019 based on [latest official notification](https://app.www.gov.cn/govdata/gov/201903/22/436883/article.html). The government officially changed the holiday plan in March 22, 2019.

<!-- if your contribution is a fix -->

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes.

