### PR TITLE
2019 Labour Day Holiday Shift for China, update at 20190322

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Update 2019 Labour Day Holidays for China as changed by government recently(2019-03-22).
 
 ## v4.3.0 (2019-03-15)
 

--- a/workalendar/asia/china.py
+++ b/workalendar/asia/china.py
@@ -20,7 +20,7 @@ holidays = {
     2019:
         {
             'Ching Ming Festival': [(4, 5)],
-            'Labour Day Holiday': [(5, 1)],
+            'Labour Day Holiday': [(5, 1), (5, 2), (5, 3)],
             'Dragon Boat Festival': [(6, 7)],
             'Mid-Autumn Festival': [(9, 13)]
         },
@@ -38,6 +38,7 @@ workdays = {
     2019:
         {
             'Spring Festival Shift': [(2, 2), (2, 3)],
+            'Labour Day Holiday Shift': [(4, 28), (5, 5)],
             'National Day Shift': [(9, 29), (10, 12)],
         },
 }

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -31,11 +31,11 @@ class ChinaTest(GenericCalendarTest):
 
     def test_year_2019(self):
         holidays = self.cal.holidays_set(2019)
-        self.assertNotIn(date(2019, 4, 28), holidays)  # Labour Day Holiday Shift
+        self.assertNotIn(date(2019, 4, 28), holidays)  # Labour Day Shift
         self.assertIn(date(2019, 5, 1), holidays)  # Labour Day Holiday
         self.assertIn(date(2019, 5, 2), holidays)  # Labour Day Holiday
         self.assertIn(date(2019, 5, 3), holidays)  # Labour Day Holiday
-        self.assertNotIn(date(2019, 5, 5), holidays)  # Labour Day Holiday Shift
+        self.assertNotIn(date(2019, 5, 5), holidays)  # Labour Day Shift
 
 
 class HongKongTest(GenericCalendarTest):

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -29,6 +29,14 @@ class ChinaTest(GenericCalendarTest):
         self.assertIn(date(2018, 12, 30), holidays)  # New year
         self.assertIn(date(2018, 12, 31), holidays)  # New year
 
+    def test_year_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertNotIn(date(2019, 4, 28), holidays)  # Labour Day Holiday Shift
+        self.assertIn(date(2019, 5, 1), holidays)  # Labour Day Holiday
+        self.assertIn(date(2019, 5, 2), holidays)  # Labour Day Holiday
+        self.assertIn(date(2019, 5, 3), holidays)  # Labour Day Holiday
+        self.assertNotIn(date(2019, 5, 5), holidays)  # Labour Day Holiday Shift
+
 
 class HongKongTest(GenericCalendarTest):
 


### PR DESCRIPTION
2019 Labour Day Holiday Shift for China, update at 20190322 by Chinese government.

refs #
http://www.gov.cn/zhengce/content/2018-12/06/content_5346276.htm

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes.
