### PR TITLE
Add South African 2019 National Elections as holiday

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 - Added California specific calendars: California Education, Berkeley, San Francisco, West Hollywood (#215).
 - Added a few refactors and tests for Australia Capital Territory holiday named "Family & Community Day", that lasted from 2007 to 2017 (#25).
-
+- Added South African 2019 National Elections as holiday
 ## v4.3.1 (2019-05-03)
 
 - Bugfix: Update 2019 Labour Day Holidays for China as changed by government recently (2019-03-22), by @iamsk, and thanks to @ltyely for their patch (#345 & #347).

--- a/workalendar/africa/south_africa.py
+++ b/workalendar/africa/south_africa.py
@@ -159,5 +159,7 @@ class SouthAfrica(WesternCalendar, ChristianMixin):
             days.append((date(year, 5, 7), "National Elections"))
         if year == 2016:
             days.append((date(year, 8, 3), "Local Elections"))
+        if year == 2019:
+            days.append((date(year, 5, 8), "National Elections"))
 
         return days

--- a/workalendar/tests/test_registry_africa.py
+++ b/workalendar/tests/test_registry_africa.py
@@ -34,4 +34,5 @@ class SouthAfricaTest(GenericCalendarTest):
         holidays = self.cal.holidays_set(2019)
 
         # variable days
-        self.assertIn(date(2019, 5, 8), holidays)
+        self.assertIn(date(2019, 5, 8), holidays)  # 2019 National Elections
+        self.assertNotIn(date(2017, 5, 8), holidays)

--- a/workalendar/tests/test_registry_africa.py
+++ b/workalendar/tests/test_registry_africa.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 from unittest import TestCase
+from datetime import date
+from workalendar.tests import GenericCalendarTest
 
 from workalendar.africa import (
     Algeria,
@@ -23,3 +25,13 @@ class RegistryAfrica(TestCase):
         self.assertIn(Madagascar, classes)
         self.assertIn(SaoTomeAndPrincipe, classes)
         self.assertIn(SouthAfrica, classes)
+
+
+class SouthAfricaTest(GenericCalendarTest):
+    cal_class = SouthAfrica
+
+    def test_south_africa_2019(self):
+        holidays = self.cal.holidays_set(2019)
+
+        # variable days
+        self.assertIn(date(2019, 5, 8), holidays)


### PR DESCRIPTION
refs #

Added May 8th as a South African Holiday for the 2019 National Elections. https://en.wikipedia.org/wiki/2019_South_African_general_election 

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes.
