### PR TITLE
Richard ob south africa national elections 2019

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Added California specific calendars: California Education, Berkeley, San Francisco, West Hollywood (#215).
 - Added a few refactors and tests for Australia Capital Territory holiday named "Family & Community Day", that lasted from 2007 to 2017 (#25).
+- Added South African 2019 National Elections as holiday (#350), by @RichardOB.
 
 ## v4.3.1 (2019-05-03)
 

--- a/workalendar/africa/south_africa.py
+++ b/workalendar/africa/south_africa.py
@@ -159,5 +159,7 @@ class SouthAfrica(WesternCalendar, ChristianMixin):
             days.append((date(year, 5, 7), "National Elections"))
         if year == 2016:
             days.append((date(year, 8, 3), "Local Elections"))
+        if year == 2019:
+            days.append((date(year, 5, 8), "National Elections"))
 
         return days

--- a/workalendar/tests/test_africa.py
+++ b/workalendar/tests/test_africa.py
@@ -455,6 +455,14 @@ class SouthAfricaTest(GenericCalendarTest):
         holidays = self.cal.holidays_set(2016)
         self.assertIn(date(2016, 8, 3), holidays)
 
+    def test_special_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 5, 8), holidays)  # 2019 National Elections
+
+        # Only in 2019
+        holidays = self.cal.holidays_set(2017)
+        self.assertNotIn(date(2017, 5, 8), holidays)
+
 
 class MadagascarTest(GenericCalendarTest):
     cal_class = Madagascar


### PR DESCRIPTION
This Pull Request supersedes and will close #350

Changes:

* fix erroneous test that was not pointing at the right year,
* moved the test into the canonical `SouthAfricaTest` class in `test_africa.py`
* changelog adjustements, to give @RichardOB all credits due :o)