### PR TITLE
Drop Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ matrix:
     - python: 2.7
       env: TOXENV=py27
 
-    - python: 3.4
-      env: TOXENV=py34
-
     - python: 3.5
       env: TOXENV=py35
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Drop Python 3.4 support (#352).
 
 ## v4.4.0 (2019-05-17)
 

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ External dependencies
 You may want to install ``python-dev`` and/or ``python3-dev`` on your machine to
 either run the installation or run tests via tox.
 
-Workalendar has been tested on Python 2.7, 3.4, 3.5, 3.6, 3.7.
+Workalendar has been tested on Python 2.7, 3.5, 3.6, 3.7.
 
 Tests
 =====

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ params = dict(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py27,flake8,py34,py35,py36,py37,py36-cov,py27-cov
+envlist = py27,flake8,py35,py36,py37,py36-cov,py27-cov
 
 [testenv]
 deps =
-    py34: pandas<0.21
-    !py34: pandas
     pytest
+    pandas
     cov: pytest-cov
 
 commands_pre =


### PR DESCRIPTION
Part of #330 

- [x] Make a statement in the next release to warn that this will be the last to support Python 3.4
- [x] Next release will be a MAJOR release (master is currently 5.0.0.dev0)
- [x] Remove references to Python 3.4 in tox and travis configuration.
- [x] Remove references in README
- [x] Remove references in setup.py
