### PR TITLE
Florida specific holidays

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - Drop Python 3.4 support (#352).
+- Added Florida specific calendars: Florida Legal, Florida Circuit Courts, Miami-Dade (#216).
 
 ## v4.4.0 (2019-05-17)
 

--- a/README.rst
+++ b/README.rst
@@ -130,6 +130,8 @@ America
   * Chicago, Illinois
   * Guam
   * Suffolk County, Massachusetts
+  * California Education, Berkeley, San Francisco, West Hollywood
+  * Florida Legal and Florida Circuit Courts, Miami-Dade
 * Canada (including provincial and territory holidays)
 
 Asia

--- a/workalendar/usa/__init__.py
+++ b/workalendar/usa/__init__.py
@@ -16,7 +16,9 @@ from .colorado import Colorado
 from .connecticut import Connecticut
 from .delaware import Delaware
 from .district_columbia import DistrictOfColumbia
-from .florida import Florida
+from .florida import (
+    Florida, FloridaLegal, FloridaCircuitCourts, FloridaMiamiDade
+)
 from .georgia import Georgia
 from .hawaii import Hawaii
 from .idaho import Idaho
@@ -77,7 +79,7 @@ __all__ = [
     'Connecticut',
     'Delaware',
     'DistrictOfColumbia',
-    'Florida',
+    'Florida', 'FloridaLegal', 'FloridaCircuitCourts', 'FloridaMiamiDade',
     'Georgia',
     'Hawaii',
     'Idaho',

--- a/workalendar/usa/alabama.py
+++ b/workalendar/usa/alabama.py
@@ -15,20 +15,7 @@ class Alabama(UnitedStates):
     presidents_day_label = "George Washington/Thomas Jefferson Birthday"
     columbus_day_label = ("Columbus Day / Fraternal Day /"
                           " American Indian Heritage Day")
-
-    def get_jefferson_davis_birthday(self, year):
-        """
-        The first MON of June is Jefferson Davis Birthday
-        """
-        return (
-            self.get_nth_weekday_in_month(year, 6, MON, 1),
-            "Jefferson Davis Birthday"
-        )
-
-    def get_variable_days(self, year):
-        days = super(Alabama, self).get_variable_days(year)
-        days.append(self.get_jefferson_davis_birthday(year))
-        return days
+    include_jefferson_davis_birthday = True
 
 
 class AlabamaBaldwinCounty(Alabama):

--- a/workalendar/usa/core.py
+++ b/workalendar/usa/core.py
@@ -36,6 +36,8 @@ class UnitedStates(WesternCalendar, ChristianMixin):
     columbus_day_label = "Columbus Day"
     # Confederation day
     include_confederation_day = False
+    # Jefferson Davis Birthday.
+    include_jefferson_davis_birthday = False
 
     # Include Cesar Chavez day(s)
     include_cesar_chavez_day = False
@@ -154,6 +156,15 @@ class UnitedStates(WesternCalendar, ChristianMixin):
         """
         day = self.get_nth_weekday_in_month(year, 4, MON, 4)
         return (day, "Confederate Memorial Day")
+
+    def get_jefferson_davis_birthday(self, year):
+        """
+        The first MON of June is Jefferson Davis Birthday
+        """
+        return (
+            self.get_nth_weekday_in_month(year, 6, MON, 1),
+            "Jefferson Davis Birthday"
+        )
 
     def get_martin_luther_king_date(self, year):
         """
@@ -307,6 +318,9 @@ class UnitedStates(WesternCalendar, ChristianMixin):
 
         if self.include_confederation_day:
             days.append(self.get_confederate_day(year))
+
+        if self.include_jefferson_davis_birthday:
+            days.append(self.get_jefferson_davis_birthday(year))
 
         if self.include_inauguration_day:
             # Is it a "Inauguration year"?

--- a/workalendar/usa/florida.py
+++ b/workalendar/usa/florida.py
@@ -1,9 +1,68 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, unicode_literals
+
+from datetime import date, timedelta
+import warnings
+from pyluach.dates import GregorianDate
 
 from .core import UnitedStates
 from ..registry import iso_register
+
+
+class HebrewHolidays(object):
+
+    hebrew_calendars = {}
+
+    @classmethod
+    def get_hebrew_calendar(cls, gregorian_year):
+        """
+        Build and cache the Hebrew calendar for the given Gregorian Year.
+        """
+        if gregorian_year not in cls.hebrew_calendars:
+            # Build the hebrew calendar for year
+            days = []
+            current_date = date(gregorian_year, 1, 1)
+
+            while current_date.year == gregorian_year:
+                hebrew_date = GregorianDate(
+                    year=current_date.year,
+                    month=current_date.month,
+                    day=current_date.day,
+                ).to_heb()
+                days.append(
+                    (hebrew_date, current_date)
+                )
+                current_date += timedelta(days=1)
+            # Store it in the class property
+            cls.hebrew_calendars[gregorian_year] = days
+
+        # Return the hebrew calendar
+        return cls.hebrew_calendars[gregorian_year]
+
+    @classmethod
+    def search_hebrew_calendar(cls, gregorian_year, hebrew_month, hebrew_day):
+        """
+        Search for a specific Hebrew month and day in the Hebrew calendar.
+        """
+        calendar = cls.get_hebrew_calendar(gregorian_year)
+        search = filter(lambda item: item[0].month == hebrew_month, calendar)
+        search = filter(lambda item: item[0].day == hebrew_day, search)
+        for item in search:
+            return item[1]
+
+    @classmethod
+    def get_rosh_hashanah(cls, year):
+        """
+        Return the gregorian date of the first day of Rosh Hashanah
+        """
+        return cls.search_hebrew_calendar(year, 7, 1)
+
+    @classmethod
+    def get_yom_kippur(cls, year):
+        """
+        Return the gregorian date of Yom Kippur.
+        """
+        return cls.search_hebrew_calendar(year, 7, 10)
 
 
 @iso_register('US-FL')
@@ -13,3 +72,68 @@ class Florida(UnitedStates):
     thanksgiving_friday_label = "Friday after Thanksgiving"
     include_columbus_day = False
     include_federal_presidents_day = False
+
+
+class FloridaLegal(Florida):
+    """Florida Legal Holidays"""
+    FIXED_HOLIDAYS = Florida.FIXED_HOLIDAYS + (
+        (2, 15, 'Susan B. Anthony Day'),
+        (4, 2, 'Pascua Florida Day'),
+        (6, 14, 'Flag Day'),
+    )
+    include_mardi_gras = True
+    include_lincoln_birthday = True
+    include_federal_presidents_day = True
+    include_good_friday = True
+    include_confederation_day = True
+    include_jefferson_davis_birthday = True
+    include_columbus_day = True
+    columbus_day_label = "Columbus Day and Farmers' Day"
+    include_election_day_every_year = True
+
+    def __init__(self, *args, **kwargs):
+        super(FloridaLegal, self).__init__(*args, **kwargs)
+        warnings.warn(
+            "Florida's laws separate the definitions between paid versus legal"
+            " holidays. Be warned that Florida Legal specific Holidays are not"
+            " paid holidays."
+        )
+
+    def get_confederate_day(self, year):
+        """
+        Confederation memorial day is on the April 26th for Florida Legal.
+        """
+        return (date(year, 4, 26), "Confederate Memorial Day")
+
+    def get_jefferson_davis_birthday(self, year):
+        """
+        Jefferson Davis Birthday appears to be a fixed holiday (June 3rd)
+        """
+        return (date(year, 6, 3), "Jefferson Davis Birthday")
+
+
+class FloridaCircuitCourts(HebrewHolidays, Florida):
+    """Florida Circuits Courts"""
+    include_federal_presidents_day = True
+    include_good_friday = True
+
+    def get_variable_days(self, year):
+        days = super(FloridaCircuitCourts, self).get_variable_days(year)
+
+        days.append((
+            self.get_rosh_hashanah(year),
+            "Rosh Hashanah"
+        ))
+
+        days.append((
+            self.get_yom_kippur(year),
+            "Yom Kippur"
+        ))
+
+        return days
+
+
+class FloridaMiamiDade(Florida):
+    """Miami-Dade, Florida"""
+    include_federal_presidents_day = True
+    include_columbus_day = True


### PR DESCRIPTION
Some Florida subdivisions are using a different holiday calendar:

* Florida legal holidays
* Florida circuit courts
* Miami-Dade, Florida

~~source: https://en.wikipedia.org/wiki/Public_holidays_in_the_United_States#Florida~~

Updated sources:

* https://en.wikipedia.org/wiki/Holidays_with_paid_time_off_in_the_United_States#Florida
* http://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0600-0699/0683/Sections/0683.01.html (this one contradicts the other, MLK day happens on Jan 15th vs. Jan 18th)

Requires #171 to be solved first

### Task list

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Docstrings for the Calendar class and specific methods.
- [x] Calendar country / label added to the README.rst file,
- [x] Changelog amended with a mention like: "Added ``<country>`` by ``@pseudo`` (#)"
