### PR TITLE
Malaysia Thaipusam dates for 2019 & 2020

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Drop Python 3.4 support (#352).
 - Added Florida specific calendars: Florida Legal, Florida Circuit Courts, Miami-Dade (#216).
 - Added Malaysia Thaipusam days for the year 2019 & 2020 - thx @burlak for the bug report (#354).
+- Fixed Deepavali dates for the year 2018 ; confirmed fixed dates that were set in the past.
 
 ## v4.4.0 (2019-05-17)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Drop Python 3.4 support (#352).
 - Added Florida specific calendars: Florida Legal, Florida Circuit Courts, Miami-Dade (#216).
+- Added Malaysia Thaipusam days for the year 2019 & 2020 - thx @burlak for the bug report (#354).
 
 ## v4.4.0 (2019-05-17)
 

--- a/workalendar/asia/malaysia.py
+++ b/workalendar/asia/malaysia.py
@@ -37,8 +37,8 @@ class Malaysia(ChineseNewYearCalendar, WesternCalendar, IslamicMixin):
         2015: date(2015, 11, 10),
         2016: date(2016, 10, 29),
         2017: date(2017, 10, 18),
-        2018: date(2018, 11, 7),   # This might change
-        2019: date(2019, 10, 27),  # This might change
+        2018: date(2018, 11, 6),
+        2019: date(2019, 10, 27),
         2020: date(2020, 11, 14),  # This might change
     }
 
@@ -51,9 +51,9 @@ class Malaysia(ChineseNewYearCalendar, WesternCalendar, IslamicMixin):
         2015: date(2015, 2, 3),
         2016: date(2016, 1, 25),
         2017: date(2017, 2, 9),
-        2018: date(2018, 1, 31),   # This might change
+        2018: date(2018, 1, 31),
         2019: date(2019, 1, 21),
-        2020: date(2020, 2, 8),
+        2020: date(2020, 2, 8),  # This might change
     }
     chinese_new_year_label = "First Day of Lunar New Year"
     include_chinese_second_day = True

--- a/workalendar/asia/malaysia.py
+++ b/workalendar/asia/malaysia.py
@@ -52,6 +52,8 @@ class Malaysia(ChineseNewYearCalendar, WesternCalendar, IslamicMixin):
         2016: date(2016, 1, 25),
         2017: date(2017, 2, 9),
         2018: date(2018, 1, 31),   # This might change
+        2019: date(2019, 1, 21),
+        2020: date(2020, 2, 8),
     }
     chinese_new_year_label = "First Day of Lunar New Year"
     include_chinese_second_day = True

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -224,6 +224,14 @@ class MalaysiaTest(GenericCalendarTest):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 6, 1), holidays)
 
+    def test_msia_thaipusam(self):
+        years = self.cal.MSIA_THAIPUSAM.keys()
+        # we only have them for years 2010-2020
+        self.assertEqual(
+            set(years),
+            set(range(2010, 2021))
+        )
+
 
 class QatarTest(GenericCalendarTest):
     cal_class = Qatar

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -224,6 +224,13 @@ class MalaysiaTest(GenericCalendarTest):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 6, 1), holidays)
 
+    def test_fix_deepavali_2018(self):
+        holidays = self.cal.holidays(2018)
+        holidays = dict(holidays)
+        deepavali = date(2018, 11, 6)
+        self.assertIn(deepavali, holidays)
+        self.assertEqual(holidays[deepavali], "Deepavali")
+
     def test_msia_thaipusam(self):
         years = self.cal.MSIA_THAIPUSAM.keys()
         # we only have them for years 2010-2020


### PR DESCRIPTION
closes #354

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes.
