### PR TITLE
Fixed Purim/Shushan Purim calculation once again

### DIFF
--- a/workalendar/asia/israel.py
+++ b/workalendar/asia/israel.py
@@ -44,17 +44,11 @@ class Israel(Calendar):
                 if day == 14:
                     days.append((current_date, "Purim"))
                 if day == 15:
-                    days.append((current_date, "Purim"))
-                    days.append((current_date, "Shushan Purim"))
-                elif day == 16:
                     days.append((current_date, "Shushan Purim"))
             elif month == 13:
                 if day == 14:
                     days.append((current_date, "Purim"))
                 elif day == 15:
-                    days.append((current_date, "Purim"))
-                    days.append((current_date, "Shushan Purim"))
-                elif day == 16:
                     days.append((current_date, "Shushan Purim"))
             elif month == 1 and day in {15, 21}:
                 days.append((current_date, "Pesach"))

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -446,5 +446,5 @@ class IsraelTest(GenericCalendarTest):
         self.assertIn(date(2019, 10, 20), holidays)  # Sukkot
 
         # Leap year Purim
-        self.assertIn(date(2019, 3, 21), holidays)
-        self.assertIn(date(2019, 3, 22), holidays)
+        self.assertIn(date(2019, 3, 21), holidays)  # purim
+        self.assertIn(date(2019, 3, 22), holidays)  # shushan purim


### PR DESCRIPTION
Due to a previous PR fixing the Israeli Purim holiday behaviour during leap years, a new bug was introduced.
This fixes the fix and corrects Purim/Shushan Purim calculations :)
- [X] Tests with a significant number of years to be tested for your calendar.