### PR TITLE
Fix Panama calendar independence from Spain

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,11 @@
 
 Nothing here yet.
 
+## v5.0.3 (2019-06-05)
+
+- Bugfix: Panama - Fixed incorrect independence from Spain date.
+
+
 ## v5.0.2 (2019-06-03)
 
 - Bugfix: Israel - Fixed incorrect Purim/Shushan Purim dates in jewish leap years, thx @orzarchi. This fix cancels the last (5.0.1) version, that will be deleted from PyPI.

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,10 +2,6 @@
 
 ## master (unreleased)
 
-Nothing here yet.
-
-## v5.0.3 (2019-06-05)
-
 - Bugfix: Panama - Fixed incorrect independence from Spain date.
 
 

--- a/workalendar/america/panama.py
+++ b/workalendar/america/panama.py
@@ -21,7 +21,7 @@ class Panama(WesternCalendar, ChristianMixin):
         (11, 3, "Independence Day"),
         (11, 5, "Colon Day"),
         (11, 10, "Shout in Villa de los Santos"),
-        (12, 2, "Independence from Spain"),
+        (11, 28, "Independence from Spain"),
         (12, 8, "Mothers' Day"),
     )
 

--- a/workalendar/tests/test_america.py
+++ b/workalendar/tests/test_america.py
@@ -116,7 +116,7 @@ class PanamaTest(GenericCalendarTest):
         self.assertIn(date(2013, 11, 5), holidays)  # colon day
         # Shout in Villa de los Santos
         self.assertIn(date(2013, 11, 10), holidays)
-        self.assertIn(date(2013, 12, 2), holidays)  # Independence from spain
+        self.assertIn(date(2013, 11, 28), holidays)  # Independence from spain
         self.assertIn(date(2013, 12, 8), holidays)  # mother day
         self.assertIn(date(2013, 12, 25), holidays)  # XMas
 


### PR DESCRIPTION

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes.
