### PR TITLE
Change registry mechanism to avoid circular imports

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -102,10 +102,10 @@ where needed:
     from .zhraa import Zhraa
     # ...
     __all__ = (
-        Belgium,
-        CzechRepublic,
+        'Belgium',
+        'CzechRepublic',
         # ...
-        Zhraa,
+        'Zhraa',
     )
 
 Now, we're building a test class. Edit the ``workalendar/tests/test_europe.py``
@@ -213,7 +213,7 @@ Kingdom ISO code is ``ZK``.
 
 To register, add the following::
 
-    from workalendar.registry import iso_register
+    from ..registry_tools import iso_register
 
     @iso_register('ZK')
     class Zhraa(WesternCalendar, ChristianMixin):

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+**Deprecation Warning:** *Currently the registry returns `OrderedDict` objects when you're querying for regions or subregions. Expect that the next release will preferrably return plain'ol' `dict` objects. If your scripts rely on the order of the objects returned, you'll have to sort them yourself.*
+
+- Change registry mechanism to avoid circular imports (#288).
 - Internal: Added a "Release" section to the Pull Request template.
 - Internal: Added advices on the Changelog entry in the Contributing document.
 

--- a/docs/iso-registry.md
+++ b/docs/iso-registry.md
@@ -25,6 +25,8 @@ As of version 3.0 (August/September 2018), we have introduced a global calendar 
 
 The `registry.region_registry` is an `OrderedDict` object, with the ISO code as a key, and the calendar class as the value. As a "workalendar standard", **every** calendar in the registry has a `name` property (derived from the docstring), so you'd probably be able to build a user-friendly list of available calendars, for a dropdown list, for example.
 
+**Deprecation Warning:** *Currently the registry returns `OrderedDict` objects when you're querying for regions or subregions. Expect that the next release will preferrably return plain'ol' `dict` objects. If your scripts rely on the order of the objects returned, you'll have to sort them yourself.*
+
 ## Retrieve a collection of regions
 
 Let's say you'd need only a subset of the ISO registry. For example, France, Switzerland and Canada calendars. You can use the method `items()` to filter only the calendars you want.

--- a/workalendar/africa/algeria.py
+++ b/workalendar/africa/algeria.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ..core import WesternCalendar, IslamicMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('DZ')

--- a/workalendar/africa/angola.py
+++ b/workalendar/africa/angola.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 from datetime import timedelta
 from workalendar.core import WesternCalendar
 from workalendar.core import ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('AO')

--- a/workalendar/africa/benin.py
+++ b/workalendar/africa/benin.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ..core import WesternCalendar, IslamicMixin, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('BJ')

--- a/workalendar/africa/ivory_coast.py
+++ b/workalendar/africa/ivory_coast.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ..core import WesternCalendar, IslamicMixin, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('CI')

--- a/workalendar/africa/madagascar.py
+++ b/workalendar/africa/madagascar.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('MG')

--- a/workalendar/africa/sao_tome.py
+++ b/workalendar/africa/sao_tome.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('ST')

--- a/workalendar/africa/south_africa.py
+++ b/workalendar/africa/south_africa.py
@@ -8,7 +8,7 @@ from ..core import WesternCalendar
 from ..core import SUN, MON, FRI
 from ..core import ChristianMixin
 from ..exceptions import CalendarError
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('ZA')

--- a/workalendar/america/barbados.py
+++ b/workalendar/america/barbados.py
@@ -4,7 +4,7 @@ from copy import copy
 
 from ..core import WesternCalendar, ChristianMixin
 from ..core import SUN, MON
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register("BB")

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -6,7 +6,7 @@ from datetime import timedelta, date
 
 from ..core import WesternCalendar, ChristianMixin
 from ..core import MON, SAT, SUN
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('BR')

--- a/workalendar/america/canada.py
+++ b/workalendar/america/canada.py
@@ -6,7 +6,7 @@ from datetime import date
 
 from ..core import WesternCalendar, ChristianMixin, Calendar
 from ..core import SUN, MON, SAT
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('CA')

--- a/workalendar/america/chile.py
+++ b/workalendar/america/chile.py
@@ -6,7 +6,7 @@ from datetime import date
 
 from ..core import WesternCalendar, ChristianMixin
 from ..core import MON, TUE, WED, FRI
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('CL')

--- a/workalendar/america/colombia.py
+++ b/workalendar/america/colombia.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 from datetime import timedelta, date
 
 from ..core import WesternCalendar, ChristianMixin, MON
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('CO')

--- a/workalendar/america/mexico.py
+++ b/workalendar/america/mexico.py
@@ -6,7 +6,7 @@ from datetime import date, timedelta
 
 from ..core import WesternCalendar, ChristianMixin
 from ..core import SUN, MON, SAT
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('MX')

--- a/workalendar/america/panama.py
+++ b/workalendar/america/panama.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 from datetime import timedelta
 
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('PA')

--- a/workalendar/america/paraguay.py
+++ b/workalendar/america/paraguay.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 from datetime import date
 
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('PY')

--- a/workalendar/asia/china.py
+++ b/workalendar/asia/china.py
@@ -5,7 +5,7 @@ from datetime import date
 import warnings
 
 from ..core import ChineseNewYearCalendar, WesternCalendar
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from ..exceptions import CalendarError
 
 holidays = {

--- a/workalendar/asia/hong_kong.py
+++ b/workalendar/asia/hong_kong.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 
 from ..core import ChineseNewYearCalendar, WesternCalendar
 from ..core import ChristianMixin, EphemMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('HK')

--- a/workalendar/asia/israel.py
+++ b/workalendar/asia/israel.py
@@ -5,7 +5,7 @@ from datetime import date, timedelta
 from pyluach.dates import GregorianDate, HebrewDate
 
 from ..core import Calendar, FRI, SAT
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register("IL")

--- a/workalendar/asia/japan.py
+++ b/workalendar/asia/japan.py
@@ -5,7 +5,7 @@ from datetime import date
 
 from ..core import MON, EphemMixin
 from ..core import WesternCalendar
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('JP')

--- a/workalendar/asia/malaysia.py
+++ b/workalendar/asia/malaysia.py
@@ -5,7 +5,7 @@ from datetime import date
 
 from ..core import ChineseNewYearCalendar, WesternCalendar
 from ..core import IslamicMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('MY')

--- a/workalendar/asia/qatar.py
+++ b/workalendar/asia/qatar.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ..core import Calendar
 from ..core import FRI, SAT, IslamicMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('QA')

--- a/workalendar/asia/singapore.py
+++ b/workalendar/asia/singapore.py
@@ -6,7 +6,7 @@ from datetime import date
 from ..core import (
     ChineseNewYearCalendar, WesternCalendar, ChristianMixin, IslamicMixin
 )
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('SG')

--- a/workalendar/asia/south_korea.py
+++ b/workalendar/asia/south_korea.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..core import ChineseNewYearCalendar, WesternCalendar
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('KR')

--- a/workalendar/asia/taiwan.py
+++ b/workalendar/asia/taiwan.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from ..core import ChineseNewYearCalendar, WesternCalendar
 from ..core import EphemMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('TW')

--- a/workalendar/europe/austria.py
+++ b/workalendar/europe/austria.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('AT')

--- a/workalendar/europe/belgium.py
+++ b/workalendar/europe/belgium.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('BE')

--- a/workalendar/europe/bulgaria.py
+++ b/workalendar/europe/bulgaria.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('BG')

--- a/workalendar/europe/cayman_islands.py
+++ b/workalendar/europe/cayman_islands.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 from datetime import date, timedelta
 
 from ..core import WesternCalendar, ChristianMixin, MON, SAT
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 QUEENS_BIRTHDAY_EXCEPTIONS = {

--- a/workalendar/europe/croatia.py
+++ b/workalendar/europe/croatia.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('HR')

--- a/workalendar/europe/cyprus.py
+++ b/workalendar/europe/cyprus.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from datetime import timedelta
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('CY')

--- a/workalendar/europe/czech_republic.py
+++ b/workalendar/europe/czech_republic.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('CZ')

--- a/workalendar/europe/denmark.py
+++ b/workalendar/europe/denmark.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from datetime import timedelta
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('DK')

--- a/workalendar/europe/estonia.py
+++ b/workalendar/europe/estonia.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('EE')

--- a/workalendar/europe/finland.py
+++ b/workalendar/europe/finland.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from datetime import date
 from workalendar.core import WesternCalendar, ChristianMixin
 from workalendar.core import FRI, SAT
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('FI')

--- a/workalendar/europe/france.py
+++ b/workalendar/europe/france.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('FR')

--- a/workalendar/europe/germany.py
+++ b/workalendar/europe/germany.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from datetime import date, timedelta
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('DE')

--- a/workalendar/europe/greece.py
+++ b/workalendar/europe/greece.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from workalendar.core import WesternCalendar, OrthodoxMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('GR')

--- a/workalendar/europe/hungary.py
+++ b/workalendar/europe/hungary.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('HU')

--- a/workalendar/europe/iceland.py
+++ b/workalendar/europe/iceland.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from datetime import date
 from workalendar.core import WesternCalendar, ChristianMixin
 from workalendar.core import THU, MON
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('IS')

--- a/workalendar/europe/ireland.py
+++ b/workalendar/europe/ireland.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from datetime import date, timedelta
 from workalendar.core import WesternCalendar, ChristianMixin
 from workalendar.core import MON
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('IE')

--- a/workalendar/europe/italy.py
+++ b/workalendar/europe/italy.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('IT')

--- a/workalendar/europe/latvia.py
+++ b/workalendar/europe/latvia.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from datetime import date
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('LV')

--- a/workalendar/europe/lithuania.py
+++ b/workalendar/europe/lithuania.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 from workalendar.core import SUN
 
 

--- a/workalendar/europe/luxembourg.py
+++ b/workalendar/europe/luxembourg.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('LU')

--- a/workalendar/europe/malta.py
+++ b/workalendar/europe/malta.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('MT')

--- a/workalendar/europe/netherlands.py
+++ b/workalendar/europe/netherlands.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from datetime import date
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('NL')

--- a/workalendar/europe/norway.py
+++ b/workalendar/europe/norway.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('NO')

--- a/workalendar/europe/poland.py
+++ b/workalendar/europe/poland.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('PL')

--- a/workalendar/europe/portugal.py
+++ b/workalendar/europe/portugal.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from datetime import date
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('PT')

--- a/workalendar/europe/romania.py
+++ b/workalendar/europe/romania.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from datetime import date
 from workalendar.core import WesternCalendar, OrthodoxMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('RO')

--- a/workalendar/europe/russia.py
+++ b/workalendar/europe/russia.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from workalendar.core import WesternCalendar
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('RU')

--- a/workalendar/europe/slovakia.py
+++ b/workalendar/europe/slovakia.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('SK')

--- a/workalendar/europe/slovenia.py
+++ b/workalendar/europe/slovenia.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from datetime import date
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('SI')

--- a/workalendar/europe/spain.py
+++ b/workalendar/europe/spain.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('ES')

--- a/workalendar/europe/sweden.py
+++ b/workalendar/europe/sweden.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from datetime import date
 from workalendar.core import WesternCalendar, ChristianMixin
 from workalendar.core import FRI, SAT
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('SE')

--- a/workalendar/europe/switzerland.py
+++ b/workalendar/europe/switzerland.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from datetime import date, timedelta
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('CH')

--- a/workalendar/europe/united_kingdom.py
+++ b/workalendar/europe/united_kingdom.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from datetime import date
 from workalendar.core import WesternCalendar, ChristianMixin
 from workalendar.core import MON
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('GB')

--- a/workalendar/oceania/australia.py
+++ b/workalendar/oceania/australia.py
@@ -5,7 +5,7 @@ from datetime import date, timedelta
 
 from ..core import WesternCalendar, ChristianMixin
 from ..core import MON, TUE, SAT, SUN
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('AU')

--- a/workalendar/oceania/marshall_islands.py
+++ b/workalendar/oceania/marshall_islands.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 from ..core import WesternCalendar, ChristianMixin
 from ..core import FRI
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('MH')

--- a/workalendar/oceania/new_zealand.py
+++ b/workalendar/oceania/new_zealand.py
@@ -3,7 +3,7 @@ from datetime import date, timedelta
 
 from workalendar.core import WesternCalendar, ChristianMixin
 from workalendar.core import MON, SAT, SUN
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register("NZ")

--- a/workalendar/registry_tools.py
+++ b/workalendar/registry_tools.py
@@ -1,0 +1,24 @@
+"""
+Tools to update the ISO registry.
+"""
+
+
+def iso_register(iso_code):
+    """
+    Registers Calendar class as country or region in IsoRegistry.
+
+    Registered country must set class variables ``iso`` using this decorator.
+
+    >>> from workalendar.core import Calendar
+    >>> @iso_register('MC-MR')
+    >>> class MyRegion(Calendar):
+    >>>     'My Region'
+
+    Region calendar is then retrievable from registry:
+
+    >>> calendar = registry.get_calendar_class('MC-MR')
+    """
+    def wrapper(cls):
+        cls.__iso_code = (iso_code, cls.__name__)
+        return cls
+    return wrapper

--- a/workalendar/tests/test_registry.py
+++ b/workalendar/tests/test_registry.py
@@ -38,20 +38,20 @@ class MockCalendarTest(TestCase):
         self.subregion = SubRegionCalendar
 
     def test_register(self):
-        registry = IsoRegistry()
+        registry = IsoRegistry(load_standard_modules=False)
         self.assertEqual(0, len(registry.region_registry.items()))
         registry.register('RE', self.region)
         self.assertEqual(1, len(registry.region_registry.items()))
         self.assertEqual(RegionCalendar, registry.region_registry['RE'])
 
     def test_get_calendar_class(self):
-        registry = IsoRegistry()
+        registry = IsoRegistry(load_standard_modules=False)
         registry.register('RE', self.region)
         calendar_class = registry.get_calendar_class('RE')
         self.assertEqual(calendar_class, RegionCalendar)
 
     def test_get_subregions(self):
-        registry = IsoRegistry()
+        registry = IsoRegistry(load_standard_modules=False)
         registry.register('RE', self.region)
         registry.register('RE-SR', self.subregion)
         registry.register('OR-SR', self.subregion)
@@ -60,7 +60,7 @@ class MockCalendarTest(TestCase):
         self.assertEqual(1, len(subregions))
 
     def test_get_items(self):
-        registry = IsoRegistry()
+        registry = IsoRegistry(load_standard_modules=False)
         registry.register('RE', self.region)
         registry.register('RE-SR', self.subregion)
         registry.register('OR-SR', self.subregion)

--- a/workalendar/usa/alabama.py
+++ b/workalendar/usa/alabama.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from .core import UnitedStates
 from ..core import MON
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-AL')

--- a/workalendar/usa/alaska.py
+++ b/workalendar/usa/alaska.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from .core import UnitedStates
 from workalendar.core import MON
-from workalendar.registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-AK')

--- a/workalendar/usa/american_samoa.py
+++ b/workalendar/usa/american_samoa.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
 from datetime import date
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-AS')

--- a/workalendar/usa/arizona.py
+++ b/workalendar/usa/arizona.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-AZ')

--- a/workalendar/usa/arkansas.py
+++ b/workalendar/usa/arkansas.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-AR')

--- a/workalendar/usa/california.py
+++ b/workalendar/usa/california.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from .core import UnitedStates
 from ..core import MON
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-CA')

--- a/workalendar/usa/colorado.py
+++ b/workalendar/usa/colorado.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-CO')

--- a/workalendar/usa/connecticut.py
+++ b/workalendar/usa/connecticut.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-CT')

--- a/workalendar/usa/core.py
+++ b/workalendar/usa/core.py
@@ -6,7 +6,7 @@ from datetime import date, timedelta
 
 from ..core import WesternCalendar, ChristianMixin
 from ..core import SUN, MON, TUE, WED, THU, FRI, SAT
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US')

--- a/workalendar/usa/delaware.py
+++ b/workalendar/usa/delaware.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-DE')

--- a/workalendar/usa/district_columbia.py
+++ b/workalendar/usa/district_columbia.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-DC')

--- a/workalendar/usa/florida.py
+++ b/workalendar/usa/florida.py
@@ -6,7 +6,7 @@ import warnings
 from pyluach.dates import GregorianDate
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 class HebrewHolidays(object):

--- a/workalendar/usa/georgia.py
+++ b/workalendar/usa/georgia.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 import warnings
 from datetime import date
 from ..core import MON, TUE, WED, THU, FRI, SAT
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/guam.py
+++ b/workalendar/usa/guam.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-GU')

--- a/workalendar/usa/hawaii.py
+++ b/workalendar/usa/hawaii.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..core import FRI
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 from .core import UnitedStates
 

--- a/workalendar/usa/idaho.py
+++ b/workalendar/usa/idaho.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-ID')

--- a/workalendar/usa/illinois.py
+++ b/workalendar/usa/illinois.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from ..core import MON
 
 

--- a/workalendar/usa/indiana.py
+++ b/workalendar/usa/indiana.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 import warnings
 from datetime import date
 from ..core import MON, TUE, WED, THU, FRI, SAT
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 from .core import UnitedStates
 

--- a/workalendar/usa/iowa.py
+++ b/workalendar/usa/iowa.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/kansas.py
+++ b/workalendar/usa/kansas.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 # FIXME: According to wikipedia, Kansas only has all federal holidays, except
 # the Columbus Day and Washington's Birthday.

--- a/workalendar/usa/kentucky.py
+++ b/workalendar/usa/kentucky.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-KY')

--- a/workalendar/usa/louisiana.py
+++ b/workalendar/usa/louisiana.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-LA')

--- a/workalendar/usa/maine.py
+++ b/workalendar/usa/maine.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-ME')

--- a/workalendar/usa/maryland.py
+++ b/workalendar/usa/maryland.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-MD')

--- a/workalendar/usa/massachusetts.py
+++ b/workalendar/usa/massachusetts.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-MA')

--- a/workalendar/usa/michigan.py
+++ b/workalendar/usa/michigan.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from datetime import date
 from ..core import SUN
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 from .core import UnitedStates
 

--- a/workalendar/usa/minnesota.py
+++ b/workalendar/usa/minnesota.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/mississippi.py
+++ b/workalendar/usa/mississippi.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-MS')

--- a/workalendar/usa/missouri.py
+++ b/workalendar/usa/missouri.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-MO')

--- a/workalendar/usa/montana.py
+++ b/workalendar/usa/montana.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import warnings
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-MT')

--- a/workalendar/usa/nebraska.py
+++ b/workalendar/usa/nebraska.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..core import FRI
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/nevada.py
+++ b/workalendar/usa/nevada.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..core import FRI
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/new_hampshire.py
+++ b/workalendar/usa/new_hampshire.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/new_jersey.py
+++ b/workalendar/usa/new_jersey.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/new_mexico.py
+++ b/workalendar/usa/new_mexico.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/new_york.py
+++ b/workalendar/usa/new_york.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/north_carolina.py
+++ b/workalendar/usa/north_carolina.py
@@ -6,7 +6,7 @@ import warnings
 from datetime import date
 
 from ..core import MON, TUE, WED, THU, FRI, SAT, SUN
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/north_dakota.py
+++ b/workalendar/usa/north_dakota.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/ohio.py
+++ b/workalendar/usa/ohio.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/oklahoma.py
+++ b/workalendar/usa/oklahoma.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/oregon.py
+++ b/workalendar/usa/oregon.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/pennsylvania.py
+++ b/workalendar/usa/pennsylvania.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/rhode_island.py
+++ b/workalendar/usa/rhode_island.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..core import MON
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/south_carolina.py
+++ b/workalendar/usa/south_carolina.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/south_dakota.py
+++ b/workalendar/usa/south_dakota.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/tennessee.py
+++ b/workalendar/usa/tennessee.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/texas.py
+++ b/workalendar/usa/texas.py
@@ -47,7 +47,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from datetime import date
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/utah.py
+++ b/workalendar/usa/utah.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/vermont.py
+++ b/workalendar/usa/vermont.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..core import TUE
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/virginia.py
+++ b/workalendar/usa/virginia.py
@@ -16,7 +16,7 @@ day by implementing the following class:
 
 """
 from ..core import WED, FRI
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/washington.py
+++ b/workalendar/usa/washington.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/west_virginia.py
+++ b/workalendar/usa/west_virginia.py
@@ -17,7 +17,7 @@ to include them, you may just have to create a class like this:
 """
 from datetime import date
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/wisconsin.py
+++ b/workalendar/usa/wisconsin.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/workalendar/usa/wyoming.py
+++ b/workalendar/usa/wyoming.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 


### PR DESCRIPTION
closes #288

- [x] As it's a refactor, tests are completely unchanged and mark no regression
- [x] Changelog amended with a mention describing your changes.

## Rationale

In the ticket #288, it appeared that simply importing any given calendar would import all the library because of the "auto-registration" of calendars into the ISO registry.

You just need to run the following code and inspect the last lines of the output to witness it:

```python
from trace import Trace
tracer = Trace()
# make run a simple import for a single country
tracer.run('from workalendar.europe.italy import Italy')
res = tracer.results()
# print results
res.write_results(coverdir='.cache', summary=True)
```

I've attached the ``trace-master.log`` here, which is an extract of the output when running against current master (v5.0.3).
[trace-master.log](https://github.com/peopledoc/workalendar/files/3265294/trace-master.log)

## Improvements

This current PR has a very different output. As you can see in the ``trace-288.log`` which corresponds to the same code executed on this very branch.
[trace-288.log](https://github.com/peopledoc/workalendar/files/3265300/trace-288.log)

Here's an array showing the main differences:

|                      | master code | branch "288-new-registry" |
|:---------------------|:------------|:--------------------------|
| number of lines      | 229         | 139                       |
| load Africa modules  | yes :-1:    | no :ok:                   |
| load America modules | yes :-1:    | no :ok:                   |
| load Asia modules    | yes :-1:    | no :ok:                   |
| load Europe modules  | yes :ok:    | yes :ok:                  |
| load Oceania modules | yes :-1:    | no :ok:                   |
| load Oceania modules | yes :-1:    | no :ok:                   |
| load USA modules     | yes :-1:    | no :ok:                   |

**Important Note** The API of the registry module hasn't changed, as all tests show no regression. However, it's expected to change, in order to return plain built-in ``dict`` objects instead of ``OrderedDict`` objects. A deprecation warning has been added to the Changelog and the code.