### PR TITLE
Bugfix: Fixing North Carolina shift rules when Christmas Day happens on Saturday

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Internal: Added a "Release" section to the Pull Request template.
 - Internal: Added advices on the Changelog entry in the Contributing document.
+- Bugfix: Fixing North Carolina shift rules when Christmas Day happens on Saturday (#232).
 
 ## v5.0.3 (2019-06-07)
 

--- a/workalendar/tests/test_usa.py
+++ b/workalendar/tests/test_usa.py
@@ -1261,6 +1261,7 @@ class NorthCarolinaTest(NoPresidentialDay, NoColumbus, UnitedStatesTest):
     def test_state_year_2014(self):
         holidays = self.cal.holidays_set(2014)
         self.assertIn(date(2014, 4, 18), holidays)  # Good Friday
+        self.assertIn(date(2014, 11, 27), holidays)  # Thanksgiving Thursday
         self.assertIn(date(2014, 11, 28), holidays)  # Thanksgiving Friday
         self.assertIn(date(2014, 12, 24), holidays)  # XMas Eve
         self.assertIn(date(2014, 12, 26), holidays)  # Boxing Day
@@ -1268,6 +1269,7 @@ class NorthCarolinaTest(NoPresidentialDay, NoColumbus, UnitedStatesTest):
     def test_state_year_2015(self):
         holidays = self.cal.holidays_set(2015)
         self.assertIn(date(2015, 4, 3), holidays)  # Good Friday
+        self.assertIn(date(2015, 11, 26), holidays)  # Thanksgiving Thursday
         self.assertIn(date(2015, 11, 27), holidays)  # Thanksgiving Friday
         self.assertIn(date(2015, 12, 24), holidays)  # Xmas Eve
         self.assertIn(date(2015, 12, 26), holidays)  # Boxing Day
@@ -1276,6 +1278,7 @@ class NorthCarolinaTest(NoPresidentialDay, NoColumbus, UnitedStatesTest):
         # It is different from other federal days.
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 4, 14), holidays)  # Good Friday
+        self.assertIn(date(2017, 11, 23), holidays)  # Thanksgiving Thursday
         self.assertIn(date(2017, 11, 24), holidays)  # Thanksgiving Friday
         self.assertIn(date(2017, 12, 24), holidays)  # Xmas Eve
         self.assertIn(date(2017, 12, 25), holidays)  # Xmas Day
@@ -1313,15 +1316,35 @@ class NorthCarolinaTest(NoPresidentialDay, NoColumbus, UnitedStatesTest):
         self.assertNotIn(date(2018, 12, 23), holidays)
         self.assertNotIn(date(2018, 12, 27), holidays)
 
+    def test_state_year_2019_xmas(self):
+        # XMAS falls on WED
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 12, 24), holidays)  # Day 1 - TUE
+        self.assertIn(date(2019, 12, 25), holidays)  # Day 2 - WED
+        self.assertIn(date(2019, 12, 26), holidays)  # Day 3 - THU
+        # No shift:
+        self.assertNotIn(date(2019, 12, 23), holidays)
+        self.assertNotIn(date(2019, 12, 27), holidays)
+
     def test_state_year_2020_xmas(self):
         # XMAS falls on FRI
         holidays = self.cal.holidays_set(2020)
         self.assertIn(date(2020, 12, 24), holidays)  # Day 1 - THU
         self.assertIn(date(2020, 12, 25), holidays)  # Day 2 - FRI
         self.assertIn(date(2020, 12, 28), holidays)  # Day 3 - MON
-        # 23rd adn 29th are not included
+        # 23rd and 29th are not included
         self.assertNotIn(date(2020, 12, 23), holidays)
         self.assertNotIn(date(2020, 12, 29), holidays)
+
+    def test_state_year_2021_xmas(self):
+        # XMAS falls on SAT
+        holidays = self.cal.holidays_set(2021)
+        self.assertIn(date(2021, 12, 23), holidays)  # Day 1 - THU
+        self.assertIn(date(2021, 12, 24), holidays)  # Day 2 - FRI
+        self.assertIn(date(2021, 12, 27), holidays)  # Day 3 - MON
+        # 23rd and 29th are not included
+        self.assertNotIn(date(2021, 12, 22), holidays)
+        self.assertNotIn(date(2021, 12, 28), holidays)
 
 
 class NorthDakotaTest(NoColumbus, UnitedStatesTest):

--- a/workalendar/usa/north_carolina.py
+++ b/workalendar/usa/north_carolina.py
@@ -2,7 +2,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import warnings
 from datetime import date
 
 from ..core import MON, TUE, WED, THU, FRI, SAT, SUN
@@ -36,14 +35,9 @@ class NorthCarolina(UnitedStates):
                 (date(year, 12, 28), "Boxing day shift"),
             ]
         elif xmas.weekday() == SAT:
-            warnings.warn(
-                "We didn't find any documentation about this configuration for"
-                " the Christmas shift. Please use with care or help us build"
-                " a better Workalendar"
-            )
             return [
-                (date(year, 12, 27), "Christmas Day shift"),
-                (date(year, 12, 28), "Boxing Day shift"),
+                (date(year, 12, 23), "Christmas Eve shift"),
+                (date(year, 12, 27), "Boxing Day shift"),
             ]
         elif xmas.weekday() == SUN:
             return [


### PR DESCRIPTION

refs #232 

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes.
