### PR TITLE
A better coverage handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,6 @@ matrix:
       env: TOXENV=py37
       sudo: true
 
-    # Lints and others
+    # Linters
     - python: 3.6
       env: TOXENV=flake8
-    - python: 2.7
-      env: TOXENV=py27-cov
-    - python: 3.6
-      env: TOXENV=py36-cov

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 - Bugfix: Fixing North Carolina shift rules when Christmas Day happens on Saturday (#232).
 - Documentation: rearrange country list in ``README.rst`` (sorting and fixing nested lists).
 - Documentation: Renamed and changed format of the "Contributing guidelines" document, now in Markdown (GFM variant), with a few fixes (#368).
+- Internal: remove coverage targets ; now coverage reports are displayed for each tox job, but they won't output classes with 100% coverage.
 
 ## v5.0.3 (2019-06-07)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,25 +1,17 @@
 [tox]
-envlist = py27,flake8,py35,py36,py37,py36-cov,py27-cov
+envlist = py27,flake8,py35,py36,py37
 
 [testenv]
 deps =
     pytest
     pandas
-    cov: pytest-cov
+    pytest-cov
 
 commands_pre =
     python setup.py develop
     python --version
 commands =
-    py.test {posargs: workalendar}
-
-[testenv:py36-cov]
-commands =
-    py.test --cov=workalendar {posargs: workalendar}
-
-[testenv:py27-cov]
-commands =
-    py.test --cov=workalendar {posargs: workalendar}
+    py.test --cov=workalendar --cov-report term:skip-covered {posargs: workalendar}
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
* Removed dedicated coverage tox jobs,
* Now coverage is executed for each tox job,
* Using the ``term:skip-covered`` option, only the classes with less than 100% coverage are displayed in the report, saving reading time

Bonus feature: with two less tox jobs, even with the coverage report generated for each Python version, execution time went from 2-3mn to 1mn30s on my local machine.