### PR TITLE
Display missing lines in coverage report

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Display missing lines in coverage report.
 
 ## 5.1.0 (2019-06-24)
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands_pre =
     python setup.py develop
     python --version
 commands =
-    py.test --cov=workalendar --cov-report term:skip-covered {posargs: workalendar}
+    py.test --cov=workalendar --cov-report term-missing:skip-covered {posargs: workalendar}
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
It should help tracking uncovered parts of workalendar.

- [x] Changelog amended with a mention describing your changes.

### Result for ``tox -e py27``

```
---------- coverage: platform linux2, python 2.7.15-final-0 ----------
Name                                 Stmts   Miss  Cover   Missing
------------------------------------------------------------------
workalendar/africa/south_africa.py     105      1    99%   144
workalendar/america/brazil.py          205      1    99%   399
workalendar/america/canada.py          166      2    99%   102, 338
workalendar/asia/china.py               41      8    80%   66-67, 84-85, 91-92, 100-101
workalendar/asia/israel.py              51      2    96%   65, 79
workalendar/asia/malaysia.py            36      4    89%   77-78, 83-84
workalendar/asia/singapore.py           26      2    92%   71-72
workalendar/core.py                    442      3    99%   204, 732, 828
workalendar/europe/netherlands.py       26      1    96%   39
workalendar/europe/romania.py           33      2    94%   45-46
workalendar/oceania/new_zealand.py      53      4    92%   73-74, 83-84
workalendar/registry.py                 54      3    94%   85, 126-127
workalendar/tests/test_registry.py      49      4    92%   12, 18, 25, 31
workalendar/tests/test_scotland.py     315      7    98%   282-292
workalendar/tests/test_usa.py         1098     29    97%   660-669, 777-799, 949-958, 1438-1445
workalendar/usa/core.py                160     15    91%   216-231
workalendar/usa/georgia.py              34      1    97%   40
workalendar/usa/indiana.py              42      1    98%   45
------------------------------------------------------------------
TOTAL                                 8810     90    99%

136 files skipped due to complete coverage.
```

### Results for ``tox -e py36``

```
----------- coverage: platform linux, python 3.7.3-final-0 -----------
Name                                 Stmts   Miss  Cover   Missing
------------------------------------------------------------------
workalendar/africa/south_africa.py     105      1    99%   144
workalendar/america/brazil.py          205      1    99%   399
workalendar/america/canada.py          166      2    99%   102, 338
workalendar/asia/china.py               41      8    80%   66-67, 84-85, 91-92, 100-101
workalendar/asia/israel.py              51      2    96%   65, 79
workalendar/asia/malaysia.py            36      4    89%   77-78, 83-84
workalendar/asia/singapore.py           26      2    92%   71-72
workalendar/core.py                    442      3    99%   204, 732, 828
workalendar/europe/netherlands.py       26      1    96%   39
workalendar/europe/romania.py           33      2    94%   45-46
workalendar/oceania/new_zealand.py      53      4    92%   73-74, 83-84
workalendar/registry.py                 54      3    94%   85, 126-127
workalendar/tests/test_registry.py      49      4    92%   12, 18, 25, 31
workalendar/tests/test_usa.py         1098     22    98%   777-799, 949-958, 1438-1445
workalendar/usa/core.py                160     15    91%   216-231
workalendar/usa/georgia.py              34      1    97%   40
workalendar/usa/indiana.py              42      1    98%   45
------------------------------------------------------------------
TOTAL                                 8810     76    99%

137 files skipped due to complete coverage.
```

Misses are mostly skipped tests, but there is room for small coverage improvements in some calendars.