### PR TITLE
add europe day for Luxembourg

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - Display missing lines in coverage report (#376).
+- Add "Europe Day" for Luxembourg (#377).
 
 ## v5.1.0 (2019-06-24)
 

--- a/workalendar/europe/luxembourg.py
+++ b/workalendar/europe/luxembourg.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from datetime import date
 from workalendar.core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
@@ -17,6 +18,12 @@ class Luxembourg(WesternCalendar, ChristianMixin):
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (5, 1, "Labour Day"),
-        (5, 9, "Europe Day"),
         (6, 23, "Luxembourg National Holiday"),
     )
+
+    def get_fixed_holidays(self, year):
+        days = super(Luxembourg, self).get_fixed_holidays(year)
+        if year > 2018:
+            days.append((date(year, 5, 9), "Europe Day"))
+
+        return days

--- a/workalendar/europe/luxembourg.py
+++ b/workalendar/europe/luxembourg.py
@@ -17,5 +17,6 @@ class Luxembourg(WesternCalendar, ChristianMixin):
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (5, 1, "Labour Day"),
+        (5, 9, "Europe Day"),
         (6, 23, "Luxembourg National Holiday"),
     )

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -730,6 +730,7 @@ class LuxembourgTest(GenericCalendarTest):
         self.assertIn(date(2016, 1, 1), holidays)   # new year
         self.assertIn(date(2016, 3, 28), holidays)   # easter
         self.assertIn(date(2016, 5, 1), holidays)   # labour day
+        self.assertIn(date(2016, 5, 9), holidays)   # europe day
         self.assertIn(date(2016, 5, 5), holidays)   # Ascension
         self.assertIn(date(2016, 5, 16), holidays)  # Pentecote
         self.assertIn(date(2016, 6, 23), holidays)  # Luxembourg National Day

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -738,12 +738,12 @@ class LuxembourgTest(GenericCalendarTest):
         self.assertIn(date(2016, 12, 25), holidays)  # Christmas
         self.assertIn(date(2016, 12, 26), holidays)  # St. Stephen´s Day
 
-        self.assertNotIn(date(2016, 5, 9), holidays)  # Europe Day, holiday since 2019
+        self.assertNotIn(date(2016, 5, 9), holidays)  # Europe Day (>=2019)
 
     def test_year_2019(self):
         holidays = self.cal.holidays_set(2019)
 
-        self.assertIn(date(2019, 5, 9), holidays)   # Europe Day, holiday since 2019
+        self.assertIn(date(2019, 5, 9), holidays)   # Europe Day (>=2019)
 
 
 class NetherlandsTest(GenericCalendarTest):

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -730,7 +730,6 @@ class LuxembourgTest(GenericCalendarTest):
         self.assertIn(date(2016, 1, 1), holidays)   # new year
         self.assertIn(date(2016, 3, 28), holidays)   # easter
         self.assertIn(date(2016, 5, 1), holidays)   # labour day
-        self.assertIn(date(2016, 5, 9), holidays)   # europe day
         self.assertIn(date(2016, 5, 5), holidays)   # Ascension
         self.assertIn(date(2016, 5, 16), holidays)  # Pentecote
         self.assertIn(date(2016, 6, 23), holidays)  # Luxembourg National Day
@@ -738,6 +737,13 @@ class LuxembourgTest(GenericCalendarTest):
         self.assertIn(date(2016, 11, 1), holidays)  # Toussaint
         self.assertIn(date(2016, 12, 25), holidays)  # Christmas
         self.assertIn(date(2016, 12, 26), holidays)  # St. Stephen´s Day
+
+        self.assertNotIn(date(2016, 5, 9), holidays)  # Europe Day, holiday since 2019
+
+    def test_year_2019(self):
+        holidays = self.cal.holidays_set(2019)
+
+        self.assertIn(date(2019, 5, 9), holidays)   # Europe Day, holiday since 2019
 
 
 class NetherlandsTest(GenericCalendarTest):


### PR DESCRIPTION
Since this year there is a new national holiday in Luxembourg "Europe Day".

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes.

