### PR TITLE
Fixed United Kingom's 2020 holidays

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - Refactored the package building procedure, now linked to `make package` ; added a note about this target in the PR template (#366).
+- Fixed United Kingom's 2020 holidays ; The Early May Bank Holiday has been moved to May 8th to commemorate the 75th anniversary of the end of WWII (#381).
 
 ## v5.2.0 (2019-07-04)
 

--- a/workalendar/europe/united_kingdom.py
+++ b/workalendar/europe/united_kingdom.py
@@ -26,6 +26,16 @@ class UnitedKingdom(WesternCalendar, ChristianMixin):
     }
 
     def get_early_may_bank_holiday(self, year):
+        """
+        Return Early May bank holiday
+        """
+        # Special case in 2020, for the 75th anniversary of the end of WWII.
+        if year == 2020:
+            return (
+                date(year, 5, 8),
+                "Early May bank holiday (VE day)"
+            )
+
         return (
             UnitedKingdom.get_nth_weekday_in_month(year, 5, MON),
             "Early May Bank Holiday"

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -905,6 +905,30 @@ class UnitedKingdomTest(GenericCalendarTest):
         self.assertIn(date(2016, 12, 26), holidays)  # Boxing day - Monday
         self.assertIn(date(2016, 12, 27), holidays)  # Christmas - shift to Tue
 
+    def test_2020(self):
+        holidays = self.cal.holidays_set(2020)
+        self.assertIn(date(2020, 1, 1), holidays)  # New Year
+        self.assertIn(date(2020, 4, 10), holidays)  # Good Friday
+        self.assertIn(date(2020, 4, 12), holidays)  # Easter Sunday
+        self.assertIn(date(2020, 4, 13), holidays)  # Easter Monday
+        # This is where the year 2020 becomes special:
+        # The Early May Bank Holiday has been moved to May 8th
+        # to commemorate the 75th anniversary of the end of WWII
+        self.assertNotIn(date(2020, 5, 4), holidays)
+        self.assertIn(date(2020, 5, 25), holidays)  # Spring Bank Holiday
+        self.assertIn(date(2020, 8, 31), holidays)  # Late Summer Bank Holiday
+        self.assertIn(date(2020, 12, 25), holidays)  # Christmas Day
+        self.assertIn(date(2020, 12, 26), holidays)  # 'Boxing Day
+        self.assertIn(date(2020, 12, 28), holidays)  # Boxing Day Shift
+
+        # May the 8th is VE day
+        holidays = self.cal.holidays(2020)
+        holidays = dict(holidays)
+        self.assertIn(date(2020, 5, 8), holidays)
+        self.assertEqual(
+            holidays[date(2020, 5, 8)], "Early May bank holiday (VE day)"
+        )
+
 
 class UnitedKingdomNorthernIrelandTest(UnitedKingdomTest):
     cal_class = UnitedKingdomNorthernIreland


### PR DESCRIPTION
The Early May Bank Holiday has been moved to May 8th to commemorate the 75th anniversary of the end of WWII

closes #381

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
