### PR TITLE
Fix Denmark, remove observances

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Fix Denmark, remove observances (remove Palm Sunday, Constitution Day, Christmas Eve and New Year's Eve) (#387, #386)
 
 ## v5.2.1 (2019-07-05)
 

--- a/workalendar/europe/denmark.py
+++ b/workalendar/europe/denmark.py
@@ -9,7 +9,6 @@ from ..registry_tools import iso_register
 class Denmark(WesternCalendar, ChristianMixin):
     'Denmark'
 
-    include_palm_sunday = True
     include_holy_thursday = True
     include_good_friday = True
     include_easter_sunday = True
@@ -21,12 +20,6 @@ class Denmark(WesternCalendar, ChristianMixin):
     whit_monday_label = "Pentecost Monday"
     include_boxing_day = True
     boxing_day_label = "Second Day of Christmas"
-    include_christmas_eve = True
-
-    FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (6, 5, "Constitution Day"),
-        (12, 31, "New Year's Eve")
-    )
 
     def get_store_bededag(self, year):  # 'great prayer day'
         easter_sunday = self.get_easter_sunday(year)

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -275,7 +275,6 @@ class DenmarkTest(GenericCalendarTest):
     def test_year_2015(self):
         holidays = self.cal.holidays_set(2015)
         self.assertIn(date(2015, 1, 1), holidays)    # nytaarsdag
-        self.assertIn(date(2015, 3, 29), holidays)   # palmesoendag
         self.assertIn(date(2015, 4, 2), holidays)    # skaertaarsdag
         self.assertIn(date(2015, 4, 3), holidays)    # langfredag
         self.assertIn(date(2015, 4, 5), holidays)    # paaskedag
@@ -284,11 +283,8 @@ class DenmarkTest(GenericCalendarTest):
         self.assertIn(date(2015, 5, 14), holidays)   # kristi himmelfart
         self.assertIn(date(2015, 5, 24), holidays)   # pinsedag
         self.assertIn(date(2015, 5, 25), holidays)   # 2. pinsedag
-        self.assertIn(date(2015, 6, 5), holidays)    # grundlovsdag
-        self.assertIn(date(2015, 12, 24), holidays)  # juleaftensdag
         self.assertIn(date(2015, 12, 25), holidays)  # juledag
         self.assertIn(date(2015, 12, 26), holidays)  # 2. juledag
-        self.assertIn(date(2015, 12, 31), holidays)  # nytaarsaften
 
 
 class SlovakiaTest(GenericCalendarTest):


### PR DESCRIPTION
Fix #386

According to the following sources:

https://www.timeanddate.com/holidays/denmark/2019
https://publicholidays.dk/2019-dates/

Palm Sunday, Constitution Day, Christmas Eve and New Year's Eve are Observances and not non working days
This seems to be also true for past years (checked 2015, 2010, 2000)

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*

<!-- Release management

- Commit for the tag:
    - [ ] Edit version in setup.py
    - [ ] Add version in Changelog.md ; trim things
    - [ ] Push & wait for the tests to be green
    - [ ] tag me.
    - [ ] build sdist + wheel packages (``make package``)
- Back to dev commit:
    - [ ] Edit version in setup.py
    - [ ] Add the "master / nothing to see here" in Changelog.md
    - [ ] Push & wait for the tests to be green
- [ ] Merge --ff
- Github stuff
    - [ ] Push tag in Github
    - [ ] Edit release on Github using the changelog.
    - [ ] Delete branch
- [ ] upload release on PyPI using ``twine``
- [ ] (*optional*) Make feeback on the various PR or issues.

 -->
