### PR TITLE
Improve registry tests

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 - Added 27 Brazil calendars -- thanks a lot to @luismalta & @mileo, (#409 & #415),
 - Fixes and additions to some calendars -- again, thanks to @luismalta & @mileo, (#409 & #415)
 - Added an IBGE_REGISTER to reference IBGE (brazilian) calendars with related tests (#415).
+- Improve ISO registry tests by raising an error when trying to register a non-Calendar class (#412).
 
 ## v7.0.0 (2019-09-20)
 

--- a/workalendar/exceptions.py
+++ b/workalendar/exceptions.py
@@ -13,3 +13,9 @@ class UnsupportedDateType(CalendarError):
     """
     Raised when trying to use an unsupported date/datetime type.
     """
+
+
+class ISORegistryError(CalendarError):
+    """
+    Raised when you are trying to register a non-Calendar object
+    """

--- a/workalendar/registry.py
+++ b/workalendar/registry.py
@@ -3,6 +3,9 @@ from __future__ import absolute_import, unicode_literals
 
 from importlib import import_module
 
+from .core import Calendar
+from .exceptions import ISORegistryError
+
 
 class IsoRegistry(object):
     """
@@ -40,6 +43,10 @@ class IsoRegistry(object):
         """
         Store the ``cls`` in the region_registry.
         """
+        if not issubclass(cls, Calendar):
+            raise ISORegistryError(
+                "Class `{}` is not a Calendar class".format(cls)
+            )
         self.region_registry[iso_code] = cls
 
     def load_module_from_items(self, module_name, items):

--- a/workalendar/tests/test_registry.py
+++ b/workalendar/tests/test_registry.py
@@ -1,34 +1,20 @@
-from datetime import date
 from unittest import TestCase
 
 from workalendar.registry import IsoRegistry
 from workalendar.core import Calendar
+from workalendar.exceptions import ISORegistryError
 
 
 class RegionCalendar(Calendar):
     'Region'
 
-    def holidays(self, year=None):
-        return tuple((
-            (date(year, 12, 25), 'Christmas'),
-            (date(year, 1, 1), 'New year'),
-        ))
-
-    def get_weekend_days(self):
-        return []  # no week-end, yes, it's sad
-
 
 class SubRegionCalendar(Calendar):
     'Sub Region'
 
-    def holidays(self, year=None):
-        return tuple((
-            (date(year, 12, 25), 'Christmas'),
-            (date(year, 1, 1), 'New year'),
-        ))
 
-    def get_weekend_days(self):
-        return []  # no week-end, yes, it's sad
+class NotACalendarClass(object):
+    "Not a Calendar"
 
 
 class MockCalendarTest(TestCase):
@@ -71,3 +57,8 @@ class MockCalendarTest(TestCase):
         items = registry.items(['RE'], include_subregions=False)
         self.assertEqual(1, len(items))
         self.assertIn('RE', items)
+
+    def test_register_non_calendar(self):
+        registry = IsoRegistry(load_standard_modules=False)
+        with self.assertRaises(ISORegistryError):
+            registry.register("NAC", NotACalendarClass)


### PR DESCRIPTION
refs #412

* Dropped unused lines in tests
* Trying to register a class that doesn't inherit from the core calendar class should raise an exception


- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
