### PR TITLE
Fix Denmark - re-add Christmas Eve

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Increase Malaysia coverage by adding tests for missing Deepavali & Thaipusam.
 - Increase China coverage by adding tests for special extra-holidays & extra-working days cases.
 - Added compatibility with Python 3.8 (#406).
+- Fix Denmark, re-add Christmas Eve, which is widely treated as public holiday.
 
 ## v7.0.0 (2019-09-20)
 

--- a/workalendar/europe/denmark.py
+++ b/workalendar/europe/denmark.py
@@ -20,6 +20,7 @@ class Denmark(WesternCalendar, ChristianMixin):
     whit_monday_label = "Pentecost Monday"
     include_boxing_day = True
     boxing_day_label = "Second Day of Christmas"
+    include_christmas_eve = True
 
     def get_store_bededag(self, year):  # 'great prayer day'
         easter_sunday = self.get_easter_sunday(year)

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -283,6 +283,7 @@ class DenmarkTest(GenericCalendarTest):
         self.assertIn(date(2015, 5, 14), holidays)   # kristi himmelfart
         self.assertIn(date(2015, 5, 24), holidays)   # pinsedag
         self.assertIn(date(2015, 5, 25), holidays)   # 2. pinsedag
+        self.assertIn(date(2015, 12, 24), holidays)  # juleaftensdag
         self.assertIn(date(2015, 12, 25), holidays)  # juledag
         self.assertIn(date(2015, 12, 26), holidays)  # 2. juledag
 


### PR DESCRIPTION
I've previously removed Christmas Eve from Denmark (together with some other, actually inaccurate public holidays), but as have been pointed out to me by our Danish customers - Christmas Eve is actually being treated as public holiday (even if it's legally not recognized).

Extra sources:
- https://www.officeholidays.com/countries/denmark
- https://www.feiertagskalender.ch/index.php?geo=3289&klasse=0&hl=en

In conclusion, while this stuff is always gonna be ambiguos - I think this particular setup for Denmark is a better default that more accurately represents how people deal with the public holidays there.