### PR TITLE
Geneva Calendar

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Added Geneva calendar by @cw-intellineers (#420) 
 
 ## v7.1.0 (2019-11-15)
 

--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,7 @@ Europe
 * Switzerland
 
   * Vaud
+  * Geneva
 
 * Turkey
 * United Kingdom (incl. Northern Ireland, Scotland and all its territories)

--- a/docs/iso-registry.md
+++ b/docs/iso-registry.md
@@ -56,6 +56,7 @@ Also, if you want those regions **and** their subregions, you can use the `inclu
  'CA-YT': <class 'workalendar.america.canada.Yukon'>,
  'CH': <class 'workalendar.europe.switzerland.Switzerland'>,
  'CH-VD': <class 'workalendar.europe.switzerland.Vaud'>,
+ 'CH-GE': <class 'workalendar.europe.switzerland.Geneva'>,
  'FR': <class 'workalendar.europe.france.France'>}
 ```
 

--- a/workalendar/europe/__init__.py
+++ b/workalendar/europe/__init__.py
@@ -87,6 +87,7 @@ __all__ = (
     'Sweden',
     'Switzerland',
     'Vaud',
+    'Geneva',
     'UnitedKingdom',
     'UnitedKingdomNorthernIreland',
     'Turkey',

--- a/workalendar/europe/__init__.py
+++ b/workalendar/europe/__init__.py
@@ -30,7 +30,7 @@ from .slovakia import Slovakia
 from .slovenia import Slovenia
 from .spain import Spain, Catalonia
 from .sweden import Sweden
-from .switzerland import Switzerland, Vaud
+from .switzerland import Switzerland, Vaud, Geneva
 from .united_kingdom import UnitedKingdom, UnitedKingdomNorthernIreland
 from .turkey import Turkey
 

--- a/workalendar/europe/switzerland.py
+++ b/workalendar/europe/switzerland.py
@@ -52,3 +52,32 @@ class Vaud(Switzerland):
             days.append((self.get_federal_thanksgiving_monday(year),
                          "Federal Thanksgiving Monday"))
         return days
+
+
+@iso_register('CH-GE')
+class Geneva(Switzerland):
+    'Geneva'
+
+    include_boxing_day = False
+    include_genevan_fast = True
+
+    FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
+        (8, 1, "National Holiday"),
+        (12, 31, "Creation of Geneva Republic"),
+    )
+
+    def get_genevan_fast(self, year):
+        "Thursday following the first Sunday of September"
+        september_1st = date(year, 9, 1)
+        return (
+            september_1st +
+            (6 - september_1st.weekday()) * timedelta(days=1) +  # 1st sunday
+            timedelta(days=4)  # Thursday following the 1st Sunday
+        )
+
+    def get_variable_days(self, year):
+        days = super(Geneva, self).get_variable_days(year)
+        if self.include_genevan_fast:
+            days.append((self.get_genevan_fast(year),
+                         "Genevan Fast"))
+        return days

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -33,7 +33,7 @@ from workalendar.europe import Romania
 from workalendar.europe import Russia
 from workalendar.europe import Spain, Catalonia
 from workalendar.europe import Slovenia
-from workalendar.europe import Switzerland, Vaud
+from workalendar.europe import Switzerland, Vaud, Geneva
 from workalendar.europe import UnitedKingdom
 from workalendar.europe import UnitedKingdomNorthernIreland
 from workalendar.europe import EuropeanCentralBank
@@ -1216,6 +1216,31 @@ class VaudTest(GenericCalendarTest):
         self.assertIn(date(2017, 9, 18), holidays)
         self.assertNotIn(date(2017, 5, 1), holidays)
         self.assertNotIn(date(2017, 12, 26), holidays)
+
+
+class GenevaTest(GenericCalendarTest):
+    cal_class = Geneva
+
+    def test_year_2018(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 9, 6), holidays)
+        self.assertIn(date(2018, 12, 31), holidays)
+        self.assertNotIn(date(2018, 5, 1), holidays)
+        self.assertNotIn(date(2018, 12, 26), holidays)
+
+    def test_year_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 9, 5), holidays)
+        self.assertIn(date(2019, 12, 31), holidays)
+        self.assertNotIn(date(2019, 5, 1), holidays)
+        self.assertNotIn(date(2019, 12, 26), holidays)
+
+    def test_year_2020(self):
+        holidays = self.cal.holidays_set(2020)
+        self.assertIn(date(2020, 9, 10), holidays)
+        self.assertIn(date(2020, 12, 31), holidays)
+        self.assertNotIn(date(2020, 5, 1), holidays)
+        self.assertNotIn(date(2020, 12, 26), holidays)
 
 
 class EstoniaTest(GenericCalendarTest):

--- a/workalendar/tests/test_registry_europe.py
+++ b/workalendar/tests/test_registry_europe.py
@@ -8,7 +8,7 @@ from workalendar.europe import (
     Malta, Netherlands, Norway, Poland, Portugal, Romania, Russia, Slovakia,
     Slovenia, Spain,
     # Catalonia,  # TODO: Add it to registry
-    Sweden, Switzerland, Vaud, UnitedKingdom, UnitedKingdomNorthernIreland,
+    Sweden, Switzerland, Vaud, Geneva, UnitedKingdom, UnitedKingdomNorthernIreland,
 )
 
 # Germany
@@ -65,6 +65,7 @@ class RegistryEurope(TestCase):
         self.assertIn(Sweden, classes)
         self.assertIn(Switzerland, classes)
         self.assertIn(Vaud, classes)
+        self.assertIn(Geneva, classes)
         self.assertIn(UnitedKingdom, classes)
         self.assertIn(UnitedKingdomNorthernIreland, classes)
         # Germany & Länders

--- a/workalendar/tests/test_registry_europe.py
+++ b/workalendar/tests/test_registry_europe.py
@@ -8,7 +8,8 @@ from workalendar.europe import (
     Malta, Netherlands, Norway, Poland, Portugal, Romania, Russia, Slovakia,
     Slovenia, Spain,
     # Catalonia,  # TODO: Add it to registry
-    Sweden, Switzerland, Vaud, Geneva, UnitedKingdom, UnitedKingdomNorthernIreland,
+    Sweden, Switzerland, Vaud, Geneva, UnitedKingdom,
+    UnitedKingdomNorthernIreland,
 )
 
 # Germany


### PR DESCRIPTION
refs #420 

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Docstrings for the Calendar class and specific methods.
- [x] Use the ``workalendar.registry_tools.iso_register`` decorator to register your new calendar using ISO codes (optional).
- [x] Calendar country / label added to the README.rst file.
- [x] Changelog amended with a mention like: "Added ``<country>`` by ``@pseudo`` (#)". **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*

