### PR TITLE
Fix USA: correct implementation for Thanksgiving Friday

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Bugfix for USA: Fixed incorrect implementation for Thanksgiving Friday.
 
 ## v7.1.0 (2019-11-15)
 

--- a/workalendar/tests/test_usa.py
+++ b/workalendar/tests/test_usa.py
@@ -452,7 +452,8 @@ class CaliforniaTest(NoColumbus, UnitedStatesTest):
         holidays = self.cal.holidays_set(2019)
         self.assertIn(date(2019, 3, 31), holidays)  # Cesar Chavez Day
         self.assertIn(date(2019, 11, 29), holidays)  # Thanksgiving Friday
-        self.assertNotIn(date(2019, 11, 22), holidays)  # Incorrect Thanksgiving Friday
+        # Incorrect Thanksgiving Friday (4th Friday of November)
+        self.assertNotIn(date(2019, 11, 22), holidays)
 
 
 class CaliforniaEducationTest(CaliforniaTest):

--- a/workalendar/tests/test_usa.py
+++ b/workalendar/tests/test_usa.py
@@ -448,6 +448,12 @@ class CaliforniaTest(NoColumbus, UnitedStatesTest):
         self.assertIn(date(2015, 3, 31), holidays)  # Cesar Chavez Day
         self.assertIn(date(2015, 11, 27), holidays)  # Thanksgiving Friday
 
+    def test_state_year_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 3, 31), holidays)  # Cesar Chavez Day
+        self.assertIn(date(2019, 11, 29), holidays)  # Thanksgiving Friday
+        self.assertNotIn(date(2019, 11, 22), holidays)  # Incorrect Thanksgiving Friday
+
 
 class CaliforniaEducationTest(CaliforniaTest):
     cal_class = CaliforniaEducation

--- a/workalendar/usa/core.py
+++ b/workalendar/usa/core.py
@@ -144,9 +144,11 @@ class UnitedStates(WesternCalendar, ChristianMixin):
         return (self.get_election_date(year), self.election_day_label)
 
     def get_thanksgiving_friday(self, year):
-        "Thanksgiving friday is on the 4th Friday in November"
+        """
+        Thanksgiving friday is on the day following Thanksgiving Day
+        """
         return (
-            self.get_nth_weekday_in_month(year, 11, FRI, 4),
+            self.get_nth_weekday_in_month(year, 11, THU, 4) + timedelta(days=1),
             self.thanksgiving_friday_label
         )
 

--- a/workalendar/usa/core.py
+++ b/workalendar/usa/core.py
@@ -147,10 +147,9 @@ class UnitedStates(WesternCalendar, ChristianMixin):
         """
         Thanksgiving friday is on the day following Thanksgiving Day
         """
+        thanksgiving = UnitedStates.get_nth_weekday_in_month(year, 11, THU, 4)
         return (
-            self.get_nth_weekday_in_month(year, 11, THU, 4) + timedelta(days=1),
-            self.thanksgiving_friday_label
-        )
+            thanksgiving + timedelta(days=1), self.thanksgiving_friday_label)
 
     def get_confederate_day(self, year):
         """


### PR DESCRIPTION
Fix: #422 

As per 
https://www.timeanddate.com/holidays/us/black-friday
https://en.wikipedia.org/wiki/Black_Friday_(shopping)
Thanksgiving Friday (informal Black Friday) is the Friday following Thanksgiving Day in the United States, which is celebrated on the fourth Thursday of November.

Current implementation-  4th Friday of November (drawing a parallel from US Thanksgiving which falls on 4th Thursday of November).
Problem - While the logic works most of the time, it fails if 1st Nov happens to be a Friday.
Proposed implementation- Thanksgiving Friday should be calculated by adding a day to the Thanksgiving date.