### PR TITLE
Refactored the computation of Genevan Fast holiday

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Small refactorings on the Gevena (Switzerland) holiday class.
 
 ## v7.1.1 (2019-11-22)
 

--- a/workalendar/europe/switzerland.py
+++ b/workalendar/europe/switzerland.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from datetime import date, timedelta
-from workalendar.core import WesternCalendar, ChristianMixin
+from ..core import WesternCalendar, ChristianMixin, SUN
 from ..registry_tools import iso_register
 
 
@@ -59,7 +59,6 @@ class Geneva(Switzerland):
     'Geneva'
 
     include_boxing_day = False
-    include_genevan_fast = True
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (8, 1, "National Holiday"),
@@ -68,16 +67,14 @@ class Geneva(Switzerland):
 
     def get_genevan_fast(self, year):
         "Thursday following the first Sunday of September"
-        september_1st = date(year, 9, 1)
+        first_sunday = self.get_nth_weekday_in_month(year, 9, SUN)
+        # The following thursday is 4 days after
         return (
-            september_1st +
-            (6 - september_1st.weekday()) * timedelta(days=1) +  # 1st sunday
-            timedelta(days=4)  # Thursday following the 1st Sunday
+            first_sunday + timedelta(days=4),
+            "Genevan Fast"
         )
 
     def get_variable_days(self, year):
         days = super(Geneva, self).get_variable_days(year)
-        if self.include_genevan_fast:
-            days.append((self.get_genevan_fast(year),
-                         "Genevan Fast"))
+        days.append(self.get_genevan_fast(year))
         return days


### PR DESCRIPTION
* using the available API to get the first SUN of september, having a more readable code
* using a more "standard" way to return the holiday, with a tuple (date, label)

refs #420
- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
