### PR TITLE
Changes in the registry.items API

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,9 @@
 
 ### ISO Registry API Change
 
-- Changes in the ``registry.items()`` method API. This method now accepts an empty/missing ``region_codes`` argument to retrieve the full registry. Please see the [ISO Registry documentation](https://peopledoc.github.io/workalendar/iso-registry.html) for extensive usage docs (#403, #375).
+- Changes in the ``registry.items()`` method API.
+  - This method is aliased to ``get_calendars()``. In a near release, the ``items()`` method will change its purpose.
+  - The ``get_calendars()`` method accepts an empty/missing ``region_codes`` argument to retrieve the full registry. Please see the [ISO Registry documentation](https://peopledoc.github.io/workalendar/iso-registry.html) for extensive usage docs (#403, #375).
 
 ## v7.2.0 (2019-12-06)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,9 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+### ISO Registry API Change
+
+- Changes in the ``registry.items()`` method API. This method now accepts an empty/missing ``region_codes`` argument to retrieve the full registry. Please see the [ISO Registry documentation](https://peopledoc.github.io/workalendar/iso-registry.html) for extensive usage docs (#403, #375).
 
 ## v7.2.0 (2019-12-06)
 

--- a/docs/iso-registry.md
+++ b/docs/iso-registry.md
@@ -8,7 +8,7 @@ As of version 3.0 (August/September 2018), we have introduced a global calendar 
 
 ```python
 >>> from workalendar.registry import registry
->>> calendars = registry.items()
+>>> calendars = registry.get_calendars()
 >>> for code, calendar_class in calendars.items():
 ...     print("`{}` is code for '{}'".format(code, calendar_class.name))
 `AT` is code for 'Austria'
@@ -26,12 +26,14 @@ As of version 3.0 (August/September 2018), we have introduced a global calendar 
 
 The "private property" `registry.region_registry` is a `dict` object, with the ISO code as a key, and the calendar class as the value. As a "workalendar standard", **every** calendar in the registry has a `name` property (derived from the docstring), so you'd probably be able to build a user-friendly list of available calendars, for a dropdown list, for example.
 
+**DEPRECATION WARNING**: the ``get_calendars`` method used to be named ``items()``. In a future release, it'll be deprecated and re-purposed. Please switch to using ``get_calendars()`` for all your queries in the registry.
+
 ## Retrieve a collection of regions
 
-If you want the full registry dictionary of **countries**, you can use the ``items()`` method.
+If you want the full dictionary of **countries**, you can use the ``get_calendars()`` method.
 
 ```python
->>> registry.items()
+>>> registry.get_calendars()
 {'AT': <class 'workalendar.europe.austria.Austria'>,
  'BE': <class 'workalendar.europe.belgium.Belgium'>,
  'BG': <class 'workalendar.europe.bulgaria.Bulgaria'>,
@@ -40,10 +42,10 @@ If you want the full registry dictionary of **countries**, you can use the ``ite
 }
 ```
 
-Let's say you'd need only a subset of the ISO registry. For example, France, Switzerland and Canada calendars. You can use the method `items()` to filter only the calendars you want.
+Let's say you'd need only a subset of the ISO registry. For example, France, Switzerland and Canada calendars. You can use the method `get_calendars()` to filter only the calendars you want.
 
 ```python
->>> registry.items(['FR', 'CH', 'CA'])
+>>> registry.get_calendars(['FR', 'CH', 'CA'])
 {'FR': <class 'workalendar.europe.france.France'>,
  'CH': <class 'workalendar.europe.switzerland.Switzerland'>,
  'CA': <class 'workalendar.america.canada.Canada'>}
@@ -52,7 +54,7 @@ Let's say you'd need only a subset of the ISO registry. For example, France, Swi
 Also, if you want those regions **and** their subregions, you can use the `include_subregions` flag:
 
 ```python
->>> registry.items(['FR', 'CH', 'CA'], include_subregions=True)
+>>> registry.get_calendars(['FR', 'CH', 'CA'], include_subregions=True)
 {'CA': <class 'workalendar.america.canada.Canada'>,
  'CA-AB': <class 'workalendar.america.canada.Alberta'>,
  'CA-BC': <class 'workalendar.america.canada.BritishColumbia'>,
@@ -78,7 +80,7 @@ Also, if you want those regions **and** their subregions, you can use the `inclu
 You can also get the full dict of all calendars registered in the ISO Registry with all the subregions using the following function call:
 
 ```python
->>> registry.items(include_subregions=True)
+>>> registry.get_calendars(include_subregions=True)
 ```
 
 ## Select only one calendar

--- a/docs/iso-registry.md
+++ b/docs/iso-registry.md
@@ -8,7 +8,8 @@ As of version 3.0 (August/September 2018), we have introduced a global calendar 
 
 ```python
 >>> from workalendar.registry import registry
->>> for code, calendar_class in registry.region_registry.items():
+>>> calendars = registry.items()
+>>> for code, calendar_class in calendars.items():
 ...     print("`{}` is code for '{}'".format(code, calendar_class.name))
 `AT` is code for 'Austria'
 `BE` is code for 'Belgium'
@@ -23,9 +24,21 @@ As of version 3.0 (August/September 2018), we have introduced a global calendar 
 ... continued
 ```
 
-The `registry.region_registry` is a `dict` object, with the ISO code as a key, and the calendar class as the value. As a "workalendar standard", **every** calendar in the registry has a `name` property (derived from the docstring), so you'd probably be able to build a user-friendly list of available calendars, for a dropdown list, for example.
+The "private property" `registry.region_registry` is a `dict` object, with the ISO code as a key, and the calendar class as the value. As a "workalendar standard", **every** calendar in the registry has a `name` property (derived from the docstring), so you'd probably be able to build a user-friendly list of available calendars, for a dropdown list, for example.
 
 ## Retrieve a collection of regions
+
+If you want the full registry dictionary of **countries**, you can use the ``items()`` method.
+
+```python
+>>> registry.items()
+{'AT': <class 'workalendar.europe.austria.Austria'>,
+ 'BE': <class 'workalendar.europe.belgium.Belgium'>,
+ 'BG': <class 'workalendar.europe.bulgaria.Bulgaria'>,
+ 'KY': <class 'workalendar.europe.cayman_islands.CaymanIslands'>,
+  # ... continued
+}
+```
 
 Let's say you'd need only a subset of the ISO registry. For example, France, Switzerland and Canada calendars. You can use the method `items()` to filter only the calendars you want.
 
@@ -61,6 +74,12 @@ Also, if you want those regions **and** their subregions, you can use the `inclu
 ```
 
 *Note*: if any of the codes is unknown, this function won't raise an error.
+
+You can also get the full dict of all calendars registered in the ISO Registry with all the subregions using the following function call:
+
+```python
+>>> registry.items(include_subregions=True)
+```
 
 ## Select only one calendar
 

--- a/workalendar/registry.py
+++ b/workalendar/registry.py
@@ -61,13 +61,6 @@ class IsoRegistry(object):
                 if iso_code and cls.__name__ == class_name:
                     self.register(iso_code, cls)
 
-    def _code_elements(self, iso_code):
-        code_elements = iso_code.split('-')
-        is_subregion = False
-        if len(code_elements) > 1:
-            is_subregion = True
-        return code_elements, is_subregion
-
     def get_calendar_class(self, iso_code):
         """
         Retrieve calendar class associated with given ``iso_code``.
@@ -96,8 +89,7 @@ class IsoRegistry(object):
         """
         items = dict()
         for key, value in self.region_registry.items():
-            code_elements, is_subregion = self._code_elements(key)
-            if is_subregion and code_elements[0] == iso_code:
+            if key.startswith("{}-".format(iso_code)):
                 items[key] = value
         return items
 

--- a/workalendar/registry.py
+++ b/workalendar/registry.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from importlib import import_module
+import warnings
 
 from .core import Calendar
 from .exceptions import ISORegistryError
@@ -94,6 +95,24 @@ class IsoRegistry(object):
         return items
 
     def items(self, region_codes=None, include_subregions=False):
+        """
+        Returns calendar classes for regions
+
+        :param region_codes list of ISO codes for selected regions. If empty,
+                            the function will return all items from the
+                            registry.
+        :param include_subregions boolean if subregions
+        of selected regions should be included in result
+        :rtype dict
+        :return dict where keys are ISO codes strings
+        and values are calendar classes
+        """
+        warnings.warn("The ``items()`` method will soon be deprecated."
+                      " Please use ``get_calendars()`` instead.",
+                      DeprecationWarning)
+        return self.get_calendars(region_codes, include_subregions)
+
+    def get_calendars(self, region_codes=None, include_subregions=False):
         """
         Returns calendar classes for regions
 

--- a/workalendar/registry.py
+++ b/workalendar/registry.py
@@ -79,14 +79,7 @@ class IsoRegistry(object):
 
         :rtype: Calendar
         """
-        code_elements, is_subregion = self._code_elements(iso_code)
-        if is_subregion and iso_code not in self.region_registry:
-            # subregion code not in region_registry
-            code = code_elements[0]
-        else:
-            # subregion code in region_registry or is not a subregion
-            code = iso_code
-        return self.region_registry.get(code)
+        return self.region_registry.get(iso_code)
 
     def get_subregions(self, iso_code):
         """

--- a/workalendar/registry.py
+++ b/workalendar/registry.py
@@ -93,17 +93,27 @@ class IsoRegistry(object):
                 items[key] = value
         return items
 
-    def items(self, region_codes, include_subregions=False):
+    def items(self, region_codes=None, include_subregions=False):
         """
         Returns calendar classes for regions
 
-        :param region_codes list of ISO codes for selected regions
+        :param region_codes list of ISO codes for selected regions. If empty,
+                            the function will return all items from the
+                            registry.
         :param include_subregions boolean if subregions
         of selected regions should be included in result
         :rtype dict
         :return dict where keys are ISO codes strings
         and values are calendar classes
         """
+        if not region_codes:
+            # Here it contains all subregions
+            if include_subregions:
+                return self.region_registry.copy()
+            items = {k: v for k, v in self.region_registry.items()
+                     if '-' not in k}
+            return items
+
         items = dict()
         for code in region_codes:
             try:

--- a/workalendar/tests/test_registry.py
+++ b/workalendar/tests/test_registry.py
@@ -48,8 +48,9 @@ class MockCalendarTest(TestCase):
         registry.register('RE-SR', self.subregion)
         registry.register('OR-SR', self.subregion)
         subregions = registry.get_subregions('RE')
-        self.assertIn('RE-SR', subregions)
+        # Only one sub-region here
         self.assertEqual(1, len(subregions))
+        self.assertIn('RE-SR', subregions)
 
     def test_get_items(self):
         registry = IsoRegistry(load_standard_modules=False)

--- a/workalendar/tests/test_registry.py
+++ b/workalendar/tests/test_registry.py
@@ -17,18 +17,23 @@ class NotACalendarClass(object):
     "Not a Calendar"
 
 
-class MockCalendarTest(TestCase):
+class NonStandardRegistryTest(TestCase):
 
     def setUp(self):
         self.region = RegionCalendar
         self.subregion = SubRegionCalendar
 
-    def test_register(self):
+    def test_region_registry(self):
         registry = IsoRegistry(load_standard_modules=False)
         self.assertEqual(0, len(registry.region_registry.items()))
         registry.register('RE', self.region)
         self.assertEqual(1, len(registry.region_registry.items()))
         self.assertEqual(RegionCalendar, registry.region_registry['RE'])
+
+    def test_register_non_calendar(self):
+        registry = IsoRegistry(load_standard_modules=False)
+        with self.assertRaises(ISORegistryError):
+            registry.register("NAC", NotACalendarClass)
 
     def test_get_calendar_class(self):
         registry = IsoRegistry(load_standard_modules=False)
@@ -52,7 +57,7 @@ class MockCalendarTest(TestCase):
         self.assertEqual(1, len(subregions))
         self.assertIn('RE-SR', subregions)
 
-    def test_get_items(self):
+    def test_items(self):
         registry = IsoRegistry(load_standard_modules=False)
         registry.register('RE', self.region)
         registry.register('RE-SR', self.subregion)
@@ -65,13 +70,8 @@ class MockCalendarTest(TestCase):
         self.assertEqual(1, len(items))
         self.assertIn('RE', items)
 
-    def test_get_items_unknown(self):
+    def test_items_unknown(self):
         registry = IsoRegistry(load_standard_modules=False)
         registry.register('RE', self.region)
         items = registry.items(['XX'])
         self.assertEqual(items, {})
-
-    def test_register_non_calendar(self):
-        registry = IsoRegistry(load_standard_modules=False)
-        with self.assertRaises(ISORegistryError):
-            registry.register("NAC", NotACalendarClass)

--- a/workalendar/tests/test_registry.py
+++ b/workalendar/tests/test_registry.py
@@ -75,3 +75,54 @@ class NonStandardRegistryTest(TestCase):
         registry.register('RE', self.region)
         items = registry.items(['XX'])
         self.assertEqual(items, {})
+
+    def test_items_with_subregions(self):
+        registry = IsoRegistry(load_standard_modules=False)
+        registry.register('RE', self.region)
+        registry.register('RE2', self.region)
+        registry.register('RE-SR', self.subregion)
+        items = registry.items(['RE2', "RE-SR"], include_subregions=True)
+        self.assertEqual(2, len(items))
+        self.assertIn('RE2', items)
+        self.assertIn('RE-SR', items)
+        items = registry.items(['RE2', "RE-SR"], include_subregions=False)
+        self.assertEqual(2, len(items))
+        self.assertIn('RE2', items)
+        self.assertIn('RE-SR', items)
+
+        # Only a subregion
+        items = registry.items(["RE-SR"], include_subregions=True)
+        self.assertEqual(1, len(items))
+        self.assertIn('RE-SR', items)
+
+    def test_items_empty_arg(self):
+        registry = IsoRegistry(load_standard_modules=False)
+        # 3 regions, one sub-region
+        registry.register('RE', self.region)
+        registry.register('RE2', self.region)
+        registry.register('RE3', self.region)
+        registry.register('RE-SR', self.subregion)
+        items = registry.items([], include_subregions=False)
+        self.assertEqual(len(items), 3)
+        self.assertEqual(set({"RE", "RE2", "RE3"}), set(items.keys()))
+        items = registry.items([], include_subregions=True)
+        self.assertEqual(len(items), 4)
+        self.assertEqual(set({"RE", "RE2", "RE3", "RE-SR"}), set(items.keys()))
+
+    def test_items_no_arg(self):
+        registry = IsoRegistry(load_standard_modules=False)
+        # 3 regions, one sub-region
+        registry.register('RE', self.region)
+        registry.register('RE2', self.region)
+        registry.register('RE3', self.region)
+        registry.register('RE-SR', self.subregion)
+
+        # Should be equivalent to [] + no subregions
+        items_no_arg = registry.items()
+        self.assertEqual(len(items_no_arg), 3)
+        self.assertEqual(set({"RE", "RE2", "RE3"}), set(items_no_arg.keys()))
+
+        # Should be equivalent to [] + include subregions
+        items = registry.items(include_subregions=True)
+        self.assertEqual(len(items), 4)
+        self.assertEqual(set({"RE", "RE2", "RE3", "RE-SR"}), set(items.keys()))

--- a/workalendar/tests/test_registry.py
+++ b/workalendar/tests/test_registry.py
@@ -33,8 +33,14 @@ class MockCalendarTest(TestCase):
     def test_get_calendar_class(self):
         registry = IsoRegistry(load_standard_modules=False)
         registry.register('RE', self.region)
+        registry.register('RE-SR', self.subregion)
         calendar_class = registry.get_calendar_class('RE')
         self.assertEqual(calendar_class, RegionCalendar)
+        # Subregion
+        calendar_class = registry.get_calendar_class('RE-SR')
+        self.assertEqual(calendar_class, SubRegionCalendar)
+        # Unknown code/region
+        self.assertIsNone(registry.get_calendar_class('XX'))
 
     def test_get_subregions(self):
         registry = IsoRegistry(load_standard_modules=False)

--- a/workalendar/tests/test_registry.py
+++ b/workalendar/tests/test_registry.py
@@ -65,6 +65,12 @@ class MockCalendarTest(TestCase):
         self.assertEqual(1, len(items))
         self.assertIn('RE', items)
 
+    def test_get_items_unknown(self):
+        registry = IsoRegistry(load_standard_modules=False)
+        registry.register('RE', self.region)
+        items = registry.items(['XX'])
+        self.assertEqual(items, {})
+
     def test_register_non_calendar(self):
         registry = IsoRegistry(load_standard_modules=False)
         with self.assertRaises(ISORegistryError):


### PR DESCRIPTION
refs #403, #375

Here are the changes in the ``registry.items()`` method API.

- This method is aliased to ``get_calendars()``. In a near release, the ``items()`` method will change its purpose.
- The ``get_calendars()`` method accepts an empty/missing ``region_codes`` argument to retrieve the full registry. Please see the [ISO Registry documentation](https://peopledoc.github.io/workalendar/iso-registry.html) for extensive usage docs.

----

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes.
- [x] Changes in documentation.