### PR TITLE
Update China's public holidays for 2020

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - Small refactorings on the Gevena (Switzerland) holiday class.
+- Update China's public holidays for 2020.
 
 ## v7.1.1 (2019-11-22)
 

--- a/workalendar/asia/china.py
+++ b/workalendar/asia/china.py
@@ -24,6 +24,13 @@ holidays = {
             'Dragon Boat Festival': [(6, 7)],
             'Mid-Autumn Festival': [(9, 13)]
         },
+    2020:
+        {
+            'Ching Ming Festival': [(4, 4), (4, 5), (4, 6)],
+            'Labour Day Holiday': [(5, 1), (5, 2), (5, 3), (5, 4), (5, 5)],
+            'Dragon Boat Festival': [(6, 25), (6, 26), (6, 27)],
+            'National Day': [(10, 8)]
+        },
 }
 
 workdays = {
@@ -40,6 +47,13 @@ workdays = {
             'Spring Festival Shift': [(2, 2), (2, 3)],
             'Labour Day Holiday Shift': [(4, 28), (5, 5)],
             'National Day Shift': [(9, 29), (10, 12)],
+        },
+    2020:
+        {
+            'Spring Festival Shift': [(1, 19), (2, 1)],
+            'Labour Day Holiday Shift': [(4, 26), (5, 9)],
+            'Dragon Boat Festival Shift': [(6, 28)],
+            'National Day Shift': [(9, 27), (10, 10)]
         },
 }
 

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -39,6 +39,27 @@ class ChinaTest(GenericCalendarTest):
         self.assertIn(date(2019, 5, 3), holidays)  # Labour Day Holiday
         self.assertNotIn(date(2019, 5, 5), holidays)  # Labour Day Shift
 
+    def test_year_2020(self):
+        holidays = self.cal.holidays_set(2020)
+        self.assertIn(date(2020, 1, 1), holidays)  # New Year
+        self.assertIn(date(2020, 1, 25), holidays)  # Spring Festival
+        self.assertIn(date(2020, 4, 4), holidays)  # Ching Ming Festival
+        self.assertIn(date(2020, 4, 6), holidays)  # Ching Ming Festival
+        self.assertIn(date(2020, 5, 1), holidays)  # Labour Day Holiday
+        self.assertIn(date(2020, 5, 5), holidays)  # Labour Day Holiday
+        self.assertIn(date(2020, 6, 25), holidays)  # Dragon Boat Festival
+        self.assertIn(date(2020, 6, 27), holidays)  # Dragon Boat Festival
+        self.assertIn(date(2020, 10, 1), holidays)  # National Day
+        self.assertIn(date(2020, 10, 8), holidays)  # National Day
+
+        self.assertNotIn(date(2020, 1, 19), holidays)  # Spring Festival Shift
+        self.assertNotIn(date(2020, 2, 1), holidays)  # Spring Festival Shift
+        self.assertNotIn(date(2020, 4, 26), holidays)  # Labour Day Shift
+        self.assertNotIn(date(2020, 5, 9), holidays)  # Labour Day Shift
+        self.assertNotIn(date(2020, 6, 28), holidays)  # Dragon Boat Shift
+        self.assertNotIn(date(2020, 9, 27), holidays)  # National Day Shift
+        self.assertNotIn(date(2020, 10, 10), holidays)  # National Day Shift
+
     def test_missing_holiday_year(self):
         save_2018 = china_holidays[2018]
         del china_holidays[2018]


### PR DESCRIPTION
ModFile:
  1. workalendar\asia\china.py
  2. workalendar\tests\test_asia.py
  3. Changelog.md

refs #
[China's public holidays  for 2020 EN](http://english.www.gov.cn/policies/infographics/201911/21/content_WS5dd677aac6d0bcf8c4c178dd.html)
[China's public holidays for 2020 CN](http://www.gov.cn/zhengce/content/2019-11/21/content_5454164.htm)
