### PR TITLE
Update Germany Hesse holidays

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - Small refactorings on the Gevena (Switzerland) holiday class.
+- Update Germany Hesse holidays
 
 ## v7.1.1 (2019-11-22)
 

--- a/workalendar/europe/germany.py
+++ b/workalendar/europe/germany.py
@@ -117,6 +117,8 @@ class Hesse(Germany):
     'Hesse'
 
     include_corpus_christi = True
+    include_easter_sunday = True
+    include_whit_sunday = True
 
 
 @iso_register('DE-MV')

--- a/workalendar/tests/test_germany.py
+++ b/workalendar/tests/test_germany.py
@@ -196,10 +196,14 @@ class HesseTest(GermanyTest):
 
     def test_extra_2014(self):
         holidays = self.cal.holidays_set(2014)
+        self.assertIn(date(2014, 4, 20), holidays)
+        self.assertIn(date(2014, 6, 8), holidays)
         self.assertIn(date(2014, 6, 19), holidays)
 
     def test_extra_2015(self):
         holidays = self.cal.holidays_set(2015)
+        self.assertIn(date(2015, 4, 5), holidays)
+        self.assertIn(date(2015, 5, 24), holidays)
         self.assertIn(date(2015, 6, 4), holidays)
 
 


### PR DESCRIPTION
Updated Germany Hesse holidays.

**Holidays for Hessia**
https://de.wikipedia.org/wiki/Gesetzliche_Feiertage_in_Deutschland

- Neujahr (New Year): 01.01.2020 (Wednesday);
- Karfreitat (Good Friday): 10.04.2020 (Friday)
- Ostersonntag (Easter Sunday): 12.04.2020 (Sunday)
- Ostermontag (Easter Monday): 13.04.2020 (Monday)
- Tag der Arbeit (Workers Day): 01.05.2020 (Friday)
- Christi Himmelfahrt: 21.05.2020 (Thursday)
- Pfingstsonntag (Pentecost Sunday): 31.05.2020 (Sunday)
- Pfingstmontag (Pentecost Monday): 01.06.2020 (Monday)
- Fronleichnam (Corpus Christi): 11.06.2020 (Thursday)
- Tag der Deutschen Einheit (Unity Day): 03.10.2020 (Saturday)
- 1. Weihnachtstag (Christmas day 1): 25.12.2020 (Friday)
- 2. Weihnachtstag (Christmas day 2): 26.12.2020 (Saturday)

