### PR TITLE
Add Deepavali and Thaipusam in 2021 for Singapore and Malaysia

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Small refactorings on the Gevena (Switzerland) holiday class.
 - Update China's public holidays for 2020.
 - Added Argentina calendar, by @ftatarli (#419).
+- Update Malaysia and Singapore for 2021 (Deepavali + Thaipusam) by @jack-pace
 
 ## v7.1.1 (2019-11-22)
 

--- a/workalendar/asia/malaysia.py
+++ b/workalendar/asia/malaysia.py
@@ -40,6 +40,7 @@ class Malaysia(ChineseNewYearCalendar, WesternCalendar, IslamicMixin):
         2018: date(2018, 11, 6),
         2019: date(2019, 10, 27),
         2020: date(2020, 11, 14),  # This might change
+        2021: date(2021, 11, 4),
     }
 
     MSIA_THAIPUSAM = {
@@ -54,6 +55,7 @@ class Malaysia(ChineseNewYearCalendar, WesternCalendar, IslamicMixin):
         2018: date(2018, 1, 31),
         2019: date(2019, 1, 21),
         2020: date(2020, 2, 8),  # This might change
+        2021: date(2021, 1, 28),
     }
     chinese_new_year_label = "First Day of Lunar New Year"
     include_chinese_second_day = True

--- a/workalendar/asia/singapore.py
+++ b/workalendar/asia/singapore.py
@@ -48,6 +48,7 @@ class Singapore(WesternCalendar,
         2018: date(2018, 11, 6),
         2019: date(2019, 10, 27),
         2020: date(2020, 11, 14),   # This might change
+        2021: date(2021, 11, 4),
     }
     chinese_new_year_label = "Chinese Lunar New Year's Day"
     include_chinese_second_day = True

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -324,10 +324,10 @@ class MalaysiaTest(GenericCalendarTest):
 
     def test_msia_thaipusam(self):
         years = self.cal.MSIA_THAIPUSAM.keys()
-        # we only have them for years 2010-2020
+        # we only have them for years 2010-2021
         self.assertEqual(
             set(years),
-            set(range(2010, 2021))
+            set(range(2010, 2022))
         )
 
     def test_missing_deepavali(self):
@@ -419,8 +419,8 @@ class SingaporeTest(GenericCalendarTest):
         self.assertIn(date(2016, 5, 2), holidays)
 
     def test_deepavali(self):
-        # At the moment, we have values for deepavali only until year 2020
-        for year in range(2000, 2021):
+        # At the moment, we have values for deepavali only until year 2021
+        for year in range(2000, 2022):
             self.assertIn(year, self.cal.DEEPAVALI)
 
     def test_deepavali_current_year(self):


### PR DESCRIPTION
refs #432 

Adds holidays in 2021 for:
  - Singapore Deepavali (https://publicholidays.sg/deepavali/)
  - Malaysia Deepavali (https://publicholidays.com.my/deepavali/)
  - Malaysia Thaipusam (https://publicholidays.com.my/thaipusam/)

<!-- if your contribution is a fix -->

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
