### PR TITLE
Remove Python 2.7 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: bionic
 language: python
 cache: pip
-install: pip install tox
+install: pip install tox tox-travis
 script: tox -v
 python:
 - 3.6
@@ -11,4 +11,4 @@ matrix:
   fast_finish: true
   include:
   - python: 3.8
-    env: TOXENV=quality
+    env: TOXENV=flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,14 @@
-sudo: false
-dist: xenial
+dist: bionic
 language: python
-install:
-    - pip install tox
-
-script:
-    - tox -e $TOXENV
-
+cache: pip
+install: pip install tox
+script: tox -v
+python:
+- 3.6
+- 3.7
+- 3.8
 matrix:
   fast_finish: true
   include:
-    # Python version is just for the look on travis.
-    - python: 2.7
-      env: TOXENV=py27
-
-    - python: 3.5
-      env: TOXENV=py35
-
-    - python: 3.6
-      env: TOXENV=py36
-
-    - python: 3.7
-      env: TOXENV=py37
-
-    - python: 3.8
-      env: TOXENV=py38
-
-    # Linters
-    - python: 3.6
-      env: TOXENV=flake8
+  - python: 3.8
+    env: TOXENV=quality

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 - Added Ukraine calendar, by @apelloni.
+- Remove Python 2.7 and Python 3.5 support.
 
 ### ISO Registry API Change
 

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ For a more complete documentation and advanced usage, go to
 External dependencies
 =====================
 
-Workalendar has been tested on Python 2.7, 3.5, 3.6, 3.7, 3.8.
+Workalendar has been tested on Python 3.6, 3.7, 3.8.
 
 If you're using wheels, you should be fine without having to install extra system packages. As of ``v7.0.0``, we have dropped ``ephem`` as a dependency for computing astronomical ephemeris in favor of ``skyfield``. So if you had any trouble because of this new dependency, during the installation or at runtime, `do not hesitate to file an issue <https://github.com/peopledoc/workalendar/issues/>`_.
 

--- a/contributing.md
+++ b/contributing.md
@@ -153,7 +153,7 @@ class Zhraa(WesternCalendar, ChristianMixin):
 
     def get_variable_days(self, year):
         # usual variable days
-        days = super(Zhraa, self).get_variable_days(year)
+        days = super().get_variable_days(year)
 
         days.append(
             (Zhraa.get_nth_weekday_in_month(year, 6, MON),

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import io
 from os.path import join, dirname, abspath
 from setuptools import setup, find_packages
@@ -49,10 +48,7 @@ params = dict(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,flake8,py35,py36,py37,py38
+envlist = py36,py37,py38
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = py36,py37,py38
+envlist = py36,py37,py38,flake8
 
 [testenv]
 deps =
     pytest
     pandas
     pytest-cov
-
 commands_pre =
     python setup.py develop
     python --version

--- a/workalendar/__init__.py
+++ b/workalendar/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pkg_resources
 
 

--- a/workalendar/africa/__init__.py
+++ b/workalendar/africa/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from .algeria import Algeria
 from .benin import Benin
 from .ivory_coast import IvoryCoast

--- a/workalendar/africa/algeria.py
+++ b/workalendar/africa/algeria.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 from ..core import WesternCalendar, IslamicMixin
 from ..registry_tools import iso_register
 

--- a/workalendar/africa/angola.py
+++ b/workalendar/africa/angola.py
@@ -26,6 +26,6 @@ class Angola(WesternCalendar, ChristianMixin):
         return easter_sunday - timedelta(days=47)
 
     def get_variable_days(self, year):
-        days = super(Angola, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append((self.get_variable_entrudo(year), "Dia de Carnaval"))
         return days

--- a/workalendar/africa/angola.py
+++ b/workalendar/africa/angola.py
@@ -1,9 +1,5 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 from datetime import timedelta
-from workalendar.core import WesternCalendar
-from workalendar.core import ChristianMixin
+from ..core import ChristianMixin, WesternCalendar
 from ..registry_tools import iso_register
 
 

--- a/workalendar/africa/benin.py
+++ b/workalendar/africa/benin.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 from ..core import WesternCalendar, IslamicMixin, ChristianMixin
 from ..registry_tools import iso_register
 

--- a/workalendar/africa/ivory_coast.py
+++ b/workalendar/africa/ivory_coast.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 from ..core import WesternCalendar, IslamicMixin, ChristianMixin
 from ..registry_tools import iso_register
 

--- a/workalendar/africa/madagascar.py
+++ b/workalendar/africa/madagascar.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 

--- a/workalendar/africa/sao_tome.py
+++ b/workalendar/africa/sao_tome.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 

--- a/workalendar/africa/south_africa.py
+++ b/workalendar/africa/south_africa.py
@@ -17,7 +17,7 @@ class SouthAfrica(WesternCalendar, ChristianMixin):
         if year < 1910:
             raise CalendarError("It's not possible to compute holidays prior"
                                 " to 1910 for South Africa.")
-        return super(SouthAfrica, self).holidays(year)
+        return super().holidays(year)
 
     def get_easter_monday_or_family_day(self, year):
         if year < 1980:
@@ -27,7 +27,7 @@ class SouthAfrica(WesternCalendar, ChristianMixin):
         return (self.get_easter_monday(year), label)
 
     def get_fixed_holidays(self, year):
-        days = super(SouthAfrica, self).get_fixed_holidays(year)
+        days = super().get_fixed_holidays(year)
         if year >= 1990:
             days.append((date(year, 3, 21), 'Human Rights Day'))
 
@@ -85,7 +85,7 @@ class SouthAfrica(WesternCalendar, ChristianMixin):
         return days
 
     def get_variable_days(self, year):
-        days = super(SouthAfrica, self).get_variable_days(year)
+        days = super().get_variable_days(year)
 
         days.append(self.get_easter_monday_or_family_day(year))
 
@@ -118,7 +118,7 @@ class SouthAfrica(WesternCalendar, ChristianMixin):
         return days
 
     def get_calendar_holidays(self, year):
-        days = super(SouthAfrica, self).get_calendar_holidays(year)
+        days = super().get_calendar_holidays(year)
         # compute shifting days
         for holiday, label in days:
             if holiday.weekday() == SUN:

--- a/workalendar/africa/south_africa.py
+++ b/workalendar/africa/south_africa.py
@@ -124,7 +124,7 @@ class SouthAfrica(WesternCalendar, ChristianMixin):
             if holiday.weekday() == SUN:
                 days.append((
                     holiday + timedelta(days=1),
-                    "%s substitute" % label
+                    f"{label} substitute"
                 ))
 
         # Other one-offs. Don't shift these

--- a/workalendar/africa/south_africa.py
+++ b/workalendar/africa/south_africa.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from datetime import timedelta, date
 
 from ..core import WesternCalendar

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .barbados import Barbados
 from .brazil import (
     Brazil, BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas,

--- a/workalendar/america/argentina.py
+++ b/workalendar/america/argentina.py
@@ -25,7 +25,7 @@ class Argentina(WesternCalendar, ChristianMixin):
 
     def get_variable_days(self, year):
 
-        days = super(Argentina, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(
             (self.get_easter_sunday(year) - timedelta(days=48),
                 "Carnival Lunes"))

--- a/workalendar/america/argentina.py
+++ b/workalendar/america/argentina.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import timedelta, date
-from workalendar.core import WesternCalendar, ChristianMixin
+from ..core import WesternCalendar, ChristianMixin
 from ..core import MON, TUE, WED, THU, FRI, SAT
 from ..registry_tools import iso_register
 

--- a/workalendar/america/barbados.py
+++ b/workalendar/america/barbados.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 from datetime import timedelta
 from copy import copy
 

--- a/workalendar/america/barbados.py
+++ b/workalendar/america/barbados.py
@@ -36,7 +36,7 @@ class Barbados(WesternCalendar, ChristianMixin):
         """
         Return variable holidays of the Barbados calendar.
         """
-        days = super(Barbados, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(self.get_kadooment_day(year))
         return days
 
@@ -46,7 +46,7 @@ class Barbados(WesternCalendar, ChristianMixin):
 
         A shift day is appended if a fixed holiday happens on SUN.
         """
-        days = super(Barbados, self).get_fixed_holidays(year)
+        days = super().get_fixed_holidays(year)
         days_to_shift = copy(days)
         for day, label in days_to_shift:
             if day.weekday() == SUN:

--- a/workalendar/america/barbados.py
+++ b/workalendar/america/barbados.py
@@ -51,6 +51,6 @@ class Barbados(WesternCalendar, ChristianMixin):
         for day, label in days_to_shift:
             if day.weekday() == SUN:
                 days.append(
-                    (day + timedelta(days=1), "%s %s" % (label, "(shifted)"))
+                    (day + timedelta(days=1), f"{label} (shifted)")
                 )
         return days

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -42,7 +42,7 @@ class Brazil(WesternCalendar, ChristianMixin):
         return self.get_easter_sunday(year) - timedelta(days=47)
 
     def get_variable_days(self, year):
-        days = super(Brazil, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         if self.include_sao_jose:
             days.append((date(year, 3, 19), self.sao_jose_label))
         if self.include_sao_pedro:
@@ -246,7 +246,7 @@ class BrazilRioDeJaneiro(Brazil):
         return BrazilRioDeJaneiro.get_nth_weekday_in_month(year, 10, MON, 3)
 
     def get_variable_days(self, year):
-        days = super(BrazilRioDeJaneiro, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append((self.get_carnaval(year), "Carnaval"))
         days.append((self.get_dia_do_comercio(year), "Dia do Comércio"))
         return days
@@ -317,7 +317,7 @@ class BrazilSaoPauloCity(BrazilSaoPauloState):
     consciencia_negra_label = "Dia da Consciência Negra"
 
     def get_variable_days(self, year):
-        days = super(BrazilSaoPauloCity, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append((self.get_carnaval(year), "Carnaval"))
         return days
 
@@ -396,7 +396,7 @@ class BrazilSerraCity(BrazilEspiritoSanto):
     include_nossa_senhora_conceicao = True
 
     def get_variable_days(self, year):
-        days = super(BrazilSerraCity, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         carnaval_tuesday = self.get_carnaval(year)
         days.append((carnaval_tuesday - timedelta(days=1), "Carnaval Monday"))
         days.append((carnaval_tuesday, "Carnaval"))

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from datetime import timedelta, date
 
 from ..core import WesternCalendar, ChristianMixin

--- a/workalendar/america/canada.py
+++ b/workalendar/america/canada.py
@@ -15,7 +15,7 @@ class Canada(WesternCalendar, ChristianMixin):
 
     def get_variable_days(self, year):
         # usual variable days
-        days = super(Canada, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(
             (Canada.get_nth_weekday_in_month(year, 9, MON, 1), "Labor Day")
         )
@@ -119,7 +119,7 @@ class Ontario(Canada, BoxingDayMixin, ThanksgivingMixin, VictoriaDayMixin,
     include_good_friday = True
 
     def get_variable_days(self, year):
-        days = super(Ontario, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend([
             (self.get_family_day(year)),
             (self.get_victoria_day(year)),
@@ -137,7 +137,7 @@ class Quebec(Canada, VictoriaDayMixin, StJeanBaptisteMixin, ThanksgivingMixin):
     include_easter_monday = True
 
     def get_variable_days(self, year):
-        days = super(Quebec, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend([
             (self.get_victoria_day(year)),
             (self.get_thanksgiving(year)),
@@ -158,7 +158,7 @@ class BritishColumbia(Canada, VictoriaDayMixin, AugustCivicHolidayMixin,
     )
 
     def get_variable_days(self, year):
-        days = super(BritishColumbia, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend([
             (self.get_family_day(year)),
             (self.get_victoria_day(year)),
@@ -178,7 +178,7 @@ class Alberta(Canada, LateFamilyDayMixin, VictoriaDayMixin, ThanksgivingMixin):
     )
 
     def get_variable_days(self, year):
-        days = super(Alberta, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend([
             (self.get_family_day(year)),
             (self.get_victoria_day(year)),
@@ -195,7 +195,7 @@ class Saskatchewan(Canada, LateFamilyDayMixin, VictoriaDayMixin,
     include_good_friday = True
 
     def get_variable_days(self, year):
-        days = super(Saskatchewan, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend([
             (self.get_family_day(year)),
             (self.get_victoria_day(year)),
@@ -213,7 +213,7 @@ class Manitoba(Canada, LateFamilyDayMixin, VictoriaDayMixin,
     include_good_friday = True
 
     def get_variable_days(self, year):
-        days = super(Manitoba, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend([
             (self.get_family_day(year, "Louis Riel Day")),
             (self.get_victoria_day(year)),
@@ -234,7 +234,7 @@ class NewBrunswick(Canada, AugustCivicHolidayMixin):
     include_good_friday = True
 
     def get_variable_days(self, year):
-        days = super(NewBrunswick, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(self.get_civic_holiday(year))
         return days
 
@@ -246,7 +246,7 @@ class NovaScotia(Canada, RemembranceDayShiftMixin, LateFamilyDayMixin):
     include_good_friday = True
 
     def get_variable_days(self, year):
-        days = super(NovaScotia, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend(self.get_remembrance_day(year))
         if year >= 2015:
             days.append(self.get_family_day(year, "Viola Desmond Day"))
@@ -260,7 +260,7 @@ class PrinceEdwardIsland(Canada, LateFamilyDayMixin, RemembranceDayShiftMixin):
     include_good_friday = True
 
     def get_variable_days(self, year):
-        days = super(PrinceEdwardIsland, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append((self.get_family_day(year, "Islander Day")))
         days.extend(self.get_remembrance_day(year))
         return days
@@ -283,7 +283,7 @@ class Yukon(Canada, VictoriaDayMixin, ThanksgivingMixin):
     include_good_friday = True
 
     def get_variable_days(self, year):
-        days = super(Yukon, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend([
             (self.get_nth_weekday_in_month(year, 8, MON, 3), "Discovery Day"),
             (self.get_victoria_day(year)),
@@ -304,7 +304,7 @@ class NorthwestTerritories(Canada, RemembranceDayShiftMixin, VictoriaDayMixin,
     include_good_friday = True
 
     def get_variable_days(self, year):
-        days = super(NorthwestTerritories, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend([
             (self.get_victoria_day(year)),
             (self.get_thanksgiving(year)),
@@ -320,7 +320,7 @@ class Nunavut(Canada, VictoriaDayMixin, ThanksgivingMixin,
     include_good_friday = True
 
     def get_variable_days(self, year):
-        days = super(Nunavut, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend([
             (self.get_victoria_day(year)),
             (self.get_thanksgiving(year)),

--- a/workalendar/america/canada.py
+++ b/workalendar/america/canada.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 from datetime import date
 
 from ..core import WesternCalendar, ChristianMixin, Calendar

--- a/workalendar/america/chile.py
+++ b/workalendar/america/chile.py
@@ -25,7 +25,7 @@ class Chile(WesternCalendar, ChristianMixin):
     include_immaculate_conception = True
 
     def get_variable_days(self, year):
-        days = super(Chile, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         september_17 = date(year, 9, 17)
         if september_17.weekday() == MON:
             days.append((september_17, '"Bridge" holiday'))

--- a/workalendar/america/chile.py
+++ b/workalendar/america/chile.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from datetime import date
 
 from ..core import WesternCalendar, ChristianMixin

--- a/workalendar/america/colombia.py
+++ b/workalendar/america/colombia.py
@@ -57,7 +57,7 @@ class Colombia(WesternCalendar, ChristianMixin):
         return Colombia.get_first_weekday_after(base_day, MON)
 
     def get_variable_days(self, year):
-        days = super(Colombia, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend([
             (self.get_epiphany(year), "Epiphany"),
             (self.get_saint_joseph(year), "Saint Joseph"),

--- a/workalendar/america/colombia.py
+++ b/workalendar/america/colombia.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from datetime import timedelta, date
 
 from ..core import WesternCalendar, ChristianMixin, MON

--- a/workalendar/america/mexico.py
+++ b/workalendar/america/mexico.py
@@ -14,7 +14,7 @@ class Mexico(WesternCalendar, ChristianMixin):
     )
 
     def get_variable_days(self, year):
-        days = super(Mexico, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(
             (Mexico.get_nth_weekday_in_month(year, 2, MON),
              "Constitution Day"))
@@ -30,7 +30,7 @@ class Mexico(WesternCalendar, ChristianMixin):
         return days
 
     def get_calendar_holidays(self, year):
-        days = super(Mexico, self).get_calendar_holidays(year)
+        days = super().get_calendar_holidays(year)
         # If any statutory day is on Sunday, the monday is off
         # If it's on a Saturday, the Friday is off
         for day, label in days:

--- a/workalendar/america/mexico.py
+++ b/workalendar/america/mexico.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from datetime import date, timedelta
 
 from ..core import WesternCalendar, ChristianMixin

--- a/workalendar/america/mexico.py
+++ b/workalendar/america/mexico.py
@@ -35,9 +35,9 @@ class Mexico(WesternCalendar, ChristianMixin):
         # If it's on a Saturday, the Friday is off
         for day, label in days:
             if day.weekday() == SAT:
-                days.append((day - timedelta(days=1), "%s substitute" % label))
+                days.append((day - timedelta(days=1), f"{label} substitute"))
             elif day.weekday() == SUN:
-                days.append((day + timedelta(days=1), "%s substitute" % label))
+                days.append((day + timedelta(days=1), f"{label} substitute"))
         # Extra: if new year's day is a saturday, the friday before is off
         next_new_year = date(year + 1, 1, 1)
         if next_new_year.weekday():

--- a/workalendar/america/panama.py
+++ b/workalendar/america/panama.py
@@ -22,7 +22,7 @@ class Panama(WesternCalendar, ChristianMixin):
     )
 
     def get_variable_days(self, year):
-        days = super(Panama, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(
             (self.get_ash_wednesday(year) - timedelta(days=1), "Carnival")
         )

--- a/workalendar/america/panama.py
+++ b/workalendar/america/panama.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from datetime import timedelta
 
 from ..core import WesternCalendar, ChristianMixin

--- a/workalendar/america/paraguay.py
+++ b/workalendar/america/paraguay.py
@@ -66,7 +66,7 @@ class Paraguay(WesternCalendar, ChristianMixin):
         """
         Return fixed holidays for Paraguay.
         """
-        days = super(Paraguay, self).get_fixed_holidays(year)
+        days = super().get_fixed_holidays(year)
         days.append(self.get_heroes_day(year))
         days.append(self.get_founding_of_asuncion(year))
         days.append(self.get_boqueron_battle_victory_day(year))

--- a/workalendar/america/paraguay.py
+++ b/workalendar/america/paraguay.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from datetime import date
 
 from ..core import WesternCalendar, ChristianMixin

--- a/workalendar/asia/__init__.py
+++ b/workalendar/asia/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .china import China
 from .hong_kong import HongKong
 from .japan import Japan, JapanBank

--- a/workalendar/asia/china.py
+++ b/workalendar/asia/china.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 from datetime import date
 import warnings
 

--- a/workalendar/asia/china.py
+++ b/workalendar/asia/china.py
@@ -66,7 +66,7 @@ class China(ChineseNewYearCalendar, WesternCalendar):
     include_chinese_new_year_eve = True
 
     def __init__(self, *args, **kwargs):
-        super(China, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.extra_working_days = []
         for year, data in workdays.items():
             for holiday_name, day_list in data.items():
@@ -77,10 +77,10 @@ class China(ChineseNewYearCalendar, WesternCalendar):
         warnings.warn("Support 2018, 2019 currently, need update every year.")
         if year not in holidays.keys():
             raise CalendarError(f"Need configure {year} for China.")
-        return super(China, self).get_calendar_holidays(year)
+        return super().get_calendar_holidays(year)
 
     def get_variable_days(self, year):
-        days = super(China, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         # Spring Festival, eve, 1.1, and 1.2 - 1.6 in lunar day
         for i in range(2, 7):
             days.append((ChineseNewYearCalendar.lunar(year, 1, i),
@@ -94,14 +94,14 @@ class China(ChineseNewYearCalendar, WesternCalendar):
     def is_working_day(self, day,
                        extra_working_days=None, extra_holidays=None):
         extra_working_days = extra_working_days or self.extra_working_days
-        return super(China, self).is_working_day(day, extra_working_days,
+        return super().is_working_day(day, extra_working_days,
                                                  extra_holidays)
 
     def add_working_days(self, day, delta,
                          extra_working_days=None, extra_holidays=None,
                          keep_datetime=False):
         extra_working_days = extra_working_days or self.extra_working_days
-        return super(China, self).add_working_days(day, delta,
+        return super().add_working_days(day, delta,
                                                    extra_working_days,
                                                    extra_holidays,
                                                    keep_datetime)
@@ -110,7 +110,7 @@ class China(ChineseNewYearCalendar, WesternCalendar):
                          extra_working_days=None, extra_holidays=None,
                          keep_datetime=False):
         extra_working_days = extra_working_days or self.extra_working_days
-        return super(China, self).sub_working_days(day, delta,
+        return super().sub_working_days(day, delta,
                                                    extra_working_days,
                                                    extra_holidays,
                                                    keep_datetime)

--- a/workalendar/asia/china.py
+++ b/workalendar/asia/china.py
@@ -76,8 +76,7 @@ class China(ChineseNewYearCalendar, WesternCalendar):
     def get_calendar_holidays(self, year):
         warnings.warn("Support 2018, 2019 currently, need update every year.")
         if year not in holidays.keys():
-            msg = "Need configure {} for China.".format(year)
-            raise CalendarError(msg)
+            raise CalendarError(f"Need configure {year} for China.")
         return super(China, self).get_calendar_holidays(year)
 
     def get_variable_days(self, year):

--- a/workalendar/asia/china.py
+++ b/workalendar/asia/china.py
@@ -95,22 +95,22 @@ class China(ChineseNewYearCalendar, WesternCalendar):
                        extra_working_days=None, extra_holidays=None):
         extra_working_days = extra_working_days or self.extra_working_days
         return super().is_working_day(day, extra_working_days,
-                                                 extra_holidays)
+                                      extra_holidays)
 
     def add_working_days(self, day, delta,
                          extra_working_days=None, extra_holidays=None,
                          keep_datetime=False):
         extra_working_days = extra_working_days or self.extra_working_days
         return super().add_working_days(day, delta,
-                                                   extra_working_days,
-                                                   extra_holidays,
-                                                   keep_datetime)
+                                        extra_working_days,
+                                        extra_holidays,
+                                        keep_datetime)
 
     def sub_working_days(self, day, delta,
                          extra_working_days=None, extra_holidays=None,
                          keep_datetime=False):
         extra_working_days = extra_working_days or self.extra_working_days
         return super().sub_working_days(day, delta,
-                                                   extra_working_days,
-                                                   extra_holidays,
-                                                   keep_datetime)
+                                        extra_working_days,
+                                        extra_holidays,
+                                        keep_datetime)

--- a/workalendar/asia/hong_kong.py
+++ b/workalendar/asia/hong_kong.py
@@ -39,7 +39,7 @@ class HongKong(WesternCalendar, ChineseNewYearCalendar, ChristianMixin):
         if year < 2011:
             self.shift_start_cny_sunday = True
 
-        days = super(HongKong, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         chingming = solar_term(year, 15, 'Asia/Hong_Kong')
         dupe_holiday = [chingming for day in days if chingming == day[0]]
         if dupe_holiday:

--- a/workalendar/asia/hong_kong.py
+++ b/workalendar/asia/hong_kong.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from datetime import timedelta
 
 from ..core import ChineseNewYearCalendar, WesternCalendar, ChristianMixin

--- a/workalendar/asia/israel.py
+++ b/workalendar/asia/israel.py
@@ -13,7 +13,7 @@ class Israel(Calendar):
     WEEKEND_DAYS = (SAT, FRI)
 
     def get_variable_days(self, year):
-        days = super(Israel, self).get_variable_days(year)
+        days = super().get_variable_days(year)
 
         delta = timedelta(days=1)
         current_date = date(year, 1, 1)

--- a/workalendar/asia/israel.py
+++ b/workalendar/asia/israel.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, unicode_literals)
 from datetime import date, timedelta
 
 from pyluach.dates import GregorianDate, HebrewDate

--- a/workalendar/asia/japan.py
+++ b/workalendar/asia/japan.py
@@ -24,7 +24,7 @@ class Japan(WesternCalendar):
         """
         Fixed holidays for Japan.
         """
-        days = super(Japan, self).get_fixed_holidays(year)
+        days = super().get_fixed_holidays(year)
         if year >= 2016:
             days.append((date(year, 8, 11), "Mountain Day"))
         # Change in Emperor
@@ -56,7 +56,7 @@ class Japan(WesternCalendar):
 
     def get_variable_days(self, year):
         # usual variable days
-        days = super(Japan, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         equinoxes = calculate_equinoxes(year, 'Asia/Tokyo')
         coming_of_age_day = Japan.get_nth_weekday_in_month(year, 1, MON, 2)
         marine_day = Japan.get_nth_weekday_in_month(year, 7, MON, 3)

--- a/workalendar/asia/japan.py
+++ b/workalendar/asia/japan.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 from datetime import date
 
 from ..core import MON

--- a/workalendar/asia/malaysia.py
+++ b/workalendar/asia/malaysia.py
@@ -63,7 +63,7 @@ class Malaysia(ChineseNewYearCalendar, WesternCalendar, IslamicMixin):
         """
         Malaysia variable days
         """
-        days = super(Malaysia, self).get_variable_days(year)
+        days = super().get_variable_days(year)
 
         # Vesak Day
         days.append(

--- a/workalendar/asia/malaysia.py
+++ b/workalendar/asia/malaysia.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 from datetime import date
 
 from ..core import ChineseNewYearCalendar, WesternCalendar

--- a/workalendar/asia/malaysia.py
+++ b/workalendar/asia/malaysia.py
@@ -73,13 +73,13 @@ class Malaysia(ChineseNewYearCalendar, WesternCalendar, IslamicMixin):
         # Add in Deepavali and Thaipusam (hardcoded dates, so no need to shift)
         msia_deepavali = self.MSIA_DEEPAVALI.get(year)
         if not msia_deepavali:
-            mdmsg = 'Missing date for Malaysia Deepavali for year: %s' % year
+            mdmsg = f'Missing date for Malaysia Deepavali for year: {year}'
             raise KeyError(mdmsg)
         days.append((msia_deepavali, 'Deepavali'))
 
         msia_thaipusam = self.MSIA_THAIPUSAM.get(year)
         if not msia_thaipusam:
-            mtmsg = 'Missing date for Malaysia Thaipusam for year: %s' % year
+            mtmsg = f'Missing date for Malaysia Thaipusam for year: {year}'
             raise KeyError(mtmsg)
         days.append((msia_thaipusam, 'Thaipusam'))
         return days

--- a/workalendar/asia/qatar.py
+++ b/workalendar/asia/qatar.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 from ..core import Calendar
 from ..core import FRI, SAT, IslamicMixin
 from ..registry_tools import iso_register

--- a/workalendar/asia/singapore.py
+++ b/workalendar/asia/singapore.py
@@ -56,7 +56,7 @@ class Singapore(WesternCalendar,
         """
         Singapore variable days
         """
-        days = super(Singapore, self).get_variable_days(year)
+        days = super().get_variable_days(year)
 
         # Vesak Day
         days.append(

--- a/workalendar/asia/singapore.py
+++ b/workalendar/asia/singapore.py
@@ -66,7 +66,7 @@ class Singapore(WesternCalendar,
         # Add in Deepavali (hardcoded dates, so no need to shift)
         deepavali = self.DEEPAVALI.get(year)
         if not deepavali:
-            msg = 'Missing date for Singapore Deepavali for year: %s' % year
+            msg = f'Missing date for Singapore Deepavali for year: {year}'
             raise KeyError(msg)
         days.append((deepavali, 'Deepavali'))
         return days

--- a/workalendar/asia/singapore.py
+++ b/workalendar/asia/singapore.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 from datetime import date
 
 from ..core import (

--- a/workalendar/asia/south_korea.py
+++ b/workalendar/asia/south_korea.py
@@ -21,7 +21,7 @@ class SouthKorea(WesternCalendar, ChineseNewYearCalendar):
     chinese_second_day_label = "Korean New Year's Day"
 
     def get_variable_days(self, year):
-        days = super(SouthKorea, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend([
             (ChineseNewYearCalendar.lunar(year, 4, 8), "Buddha's Birthday"),
             # Midautumn Festival (3 days)

--- a/workalendar/asia/south_korea.py
+++ b/workalendar/asia/south_korea.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..core import ChineseNewYearCalendar, WesternCalendar
 from ..registry_tools import iso_register
 

--- a/workalendar/asia/taiwan.py
+++ b/workalendar/asia/taiwan.py
@@ -18,7 +18,7 @@ class Taiwan(ChineseNewYearCalendar, WesternCalendar):
     include_chinese_second_day = True
 
     def get_variable_days(self, year):
-        days = super(Taiwan, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         # Qingming begins when the sun reaches the celestial
         # longitude of 15° (usually around April 4th or 5th)
         qingming = solar_term(year, 15, 'Asia/Taipei')

--- a/workalendar/asia/taiwan.py
+++ b/workalendar/asia/taiwan.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..core import ChineseNewYearCalendar, WesternCalendar
 from ..astronomy import solar_term
 from ..registry_tools import iso_register

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -15,7 +15,7 @@ from .exceptions import UnsupportedDateType
 MON, TUE, WED, THU, FRI, SAT, SUN = range(7)
 
 
-class classproperty(object):
+class classproperty:
 
     def __init__(self, getter):
         self.getter = getter
@@ -42,7 +42,7 @@ def cleaned_date(day, keep_datetime=False):
     return day
 
 
-class Calendar(object):
+class Calendar:
 
     FIXED_HOLIDAYS = ()
     WEEKEND_DAYS = ()

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Working day tools
 """

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -469,7 +469,7 @@ class ChristianMixin(Calendar):
 
     def get_variable_days(self, year):  # noqa
         "Return the christian holidays list according to the mixin"
-        days = super(ChristianMixin, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         if self.include_epiphany:
             days.append((date(year, 1, 6), "Epiphany"))
         if self.include_clean_monday:
@@ -534,7 +534,7 @@ class WesternCalendar(Calendar):
     )
 
     def get_variable_days(self, year):
-        days = super(WesternCalendar, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         new_year = date(year, 1, 1)
         if self.shift_new_years_day:
             if new_year.weekday() in self.get_weekend_days():
@@ -645,7 +645,7 @@ class ChineseNewYearCalendar(LunarCalendar):
         return days
 
     def get_variable_days(self, year):
-        days = super(ChineseNewYearCalendar, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend(self.get_chinese_new_year(year))
         return days
 
@@ -667,7 +667,7 @@ class ChineseNewYearCalendar(LunarCalendar):
         falls on SUN.
         """
         # Unshifted days are here:
-        days = super(ChineseNewYearCalendar, self).get_calendar_holidays(year)
+        days = super().get_calendar_holidays(year)
         if self.shift_sunday_holidays:
             days_to_inspect = copy(days)
             for day_shifted in self.get_shifted_holidays(days_to_inspect):
@@ -680,7 +680,7 @@ class CalverterMixin(Calendar):
     ISLAMIC_HOLIDAYS = ()
 
     def __init__(self, *args, **kwargs):
-        super(CalverterMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.calverter = Calverter()
         if self.conversion_method is None:
             raise NotImplementedError
@@ -718,7 +718,7 @@ class CalverterMixin(Calendar):
     def get_variable_days(self, year):
         warnings.warn('Please take note that, due to arbitrary decisions, '
                       'this Islamic calendar computation may be wrong.')
-        days = super(CalverterMixin, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         years = self.calverted_years(year)
         conversion_method = getattr(
             self.calverter, f'{self.conversion_method}_to_jd')
@@ -758,7 +758,7 @@ class IslamicMixin(CalverterMixin):
         """Return a list of Islamic (month, day, label) for islamic holidays.
         Please take note that these dates must be expressed using the Islamic
         Calendar"""
-        days = list(super(IslamicMixin, self).get_islamic_holidays())
+        days = list(super().get_islamic_holidays())
 
         if self.include_islamic_new_year:
             days.append((1, 1, "Islamic New Year"))

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -35,7 +35,7 @@ def cleaned_date(day, keep_datetime=False):
     """
     if not isinstance(day, (date, datetime)):
         raise UnsupportedDateType(
-            "`{}` is of unsupported type ({})".format(day, type(day)))
+            f"`{day}` is of unsupported type ({type(day)})")
     if not keep_datetime:
         if hasattr(day, 'date') and callable(day.date):
             day = day.date()
@@ -456,7 +456,7 @@ class ChristianMixin(Calendar):
         """
         christmas = date(year, 12, 25)
         boxing_day = date(year, 12, 26)
-        boxing_day_label = "{} Shift".format(self.boxing_day_label)
+        boxing_day_label = f"{self.boxing_day_label} Shift"
         results = []
         if christmas.weekday() in self.get_weekend_days():
             shift = self.find_following_working_day(christmas)
@@ -687,7 +687,7 @@ class CalverterMixin(Calendar):
 
     def converted(self, year):
         conversion_method = getattr(
-            self.calverter, 'jd_to_%s' % self.conversion_method)
+            self.calverter, f'jd_to_{self.conversion_method}')
         current = date(year, 1, 1)
         days = []
         while current.year == year:
@@ -721,7 +721,7 @@ class CalverterMixin(Calendar):
         days = super(CalverterMixin, self).get_variable_days(year)
         years = self.calverted_years(year)
         conversion_method = getattr(
-            self.calverter, '%s_to_jd' % self.conversion_method)
+            self.calverter, f'{self.conversion_method}_to_jd')
         for month, day, label in self.get_islamic_holidays():
             for y in years:
                 jd = conversion_method(y, month, day)

--- a/workalendar/europe/__init__.py
+++ b/workalendar/europe/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .austria import Austria
 from .belgium import Belgium
 from .bulgaria import Bulgaria

--- a/workalendar/europe/austria.py
+++ b/workalendar/europe/austria.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from workalendar.core import WesternCalendar, ChristianMixin
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/belgium.py
+++ b/workalendar/europe/belgium.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from workalendar.core import WesternCalendar, ChristianMixin
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/bulgaria.py
+++ b/workalendar/europe/bulgaria.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from workalendar.core import WesternCalendar, ChristianMixin
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/cayman_islands.py
+++ b/workalendar/europe/cayman_islands.py
@@ -20,7 +20,7 @@ class CaymanIslands(WesternCalendar, ChristianMixin):
     shift_new_years_day = True
 
     def get_variable_days(self, year):
-        days = super(CaymanIslands, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days += [
             (self.get_national_heroes_day(year), "National Heroes Day"),
             (self.get_discovery_day(year), "Discovery Day"),

--- a/workalendar/europe/cayman_islands.py
+++ b/workalendar/europe/cayman_islands.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from datetime import date, timedelta
 
 from ..core import WesternCalendar, ChristianMixin, MON, SAT

--- a/workalendar/europe/croatia.py
+++ b/workalendar/europe/croatia.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from workalendar.core import WesternCalendar, ChristianMixin
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/cyprus.py
+++ b/workalendar/europe/cyprus.py
@@ -29,7 +29,7 @@ class Cyprus(WesternCalendar, ChristianMixin):
     )
 
     def get_variable_days(self, year):
-        days = super(Cyprus, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append((self.get_easter_monday(year) +
                      timedelta(days=1), "Easter Tuesday"))
         return days

--- a/workalendar/europe/cyprus.py
+++ b/workalendar/europe/cyprus.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import timedelta
-from workalendar.core import WesternCalendar, ChristianMixin
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/czech_republic.py
+++ b/workalendar/europe/czech_republic.py
@@ -25,4 +25,4 @@ class CzechRepublic(WesternCalendar, ChristianMixin):
     def get_variable_days(self, year):
         # As of 2016, Good Friday became a holiday
         self.include_good_friday = (year >= 2016)
-        return super(CzechRepublic, self).get_variable_days(year)
+        return super().get_variable_days(year)

--- a/workalendar/europe/czech_republic.py
+++ b/workalendar/europe/czech_republic.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from workalendar.core import WesternCalendar, ChristianMixin
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/denmark.py
+++ b/workalendar/europe/denmark.py
@@ -26,6 +26,6 @@ class Denmark(WesternCalendar, ChristianMixin):
         return easter_sunday + timedelta(days=26)
 
     def get_variable_days(self, year):
-        days = super(Denmark, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append((self.get_store_bededag(year), "Store Bededag"))
         return days

--- a/workalendar/europe/denmark.py
+++ b/workalendar/europe/denmark.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import timedelta
-from workalendar.core import WesternCalendar, ChristianMixin
+
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/estonia.py
+++ b/workalendar/europe/estonia.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from workalendar.core import WesternCalendar, ChristianMixin
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/european_central_bank.py
+++ b/workalendar/europe/european_central_bank.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-from workalendar.core import WesternCalendar, ChristianMixin
+from ..core import WesternCalendar, ChristianMixin
 
 
 class EuropeanCentralBank(WesternCalendar, ChristianMixin):

--- a/workalendar/europe/finland.py
+++ b/workalendar/europe/finland.py
@@ -42,7 +42,7 @@ class Finland(WesternCalendar, ChristianMixin):
         return all_saints
 
     def get_variable_days(self, year):
-        days = super(Finland, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append((self.get_midsummer_eve(year), "Midsummer's Eve"))
         days.append((self.get_midsummer_day(year), "Midsummer's Day"))
         days.append((self.get_variable_all_saints(year), "All Saints"))

--- a/workalendar/europe/finland.py
+++ b/workalendar/europe/finland.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import date
-from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.core import FRI, SAT
+
+from ..core import WesternCalendar, ChristianMixin, FRI, SAT
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/france.py
+++ b/workalendar/europe/france.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from workalendar.core import WesternCalendar, ChristianMixin
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/germany.py
+++ b/workalendar/europe/germany.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import date, timedelta
-from workalendar.core import WesternCalendar, ChristianMixin
+
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/germany.py
+++ b/workalendar/europe/germany.py
@@ -46,7 +46,7 @@ class Germany(WesternCalendar, ChristianMixin):
         return (day, "Reformation Day")
 
     def get_variable_days(self, year):
-        days = super(Germany, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         if self.include_reformation_day(year):
             days.append(self.get_reformation_day(year))
         return days
@@ -84,7 +84,7 @@ class Berlin(Germany):
         return (day, "Liberation Day")
 
     def get_variable_days(self, year):
-        days = super(Berlin, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         if year >= 2019:
             days.append(self.get_international_womens_day(year))
         if year == 2020:
@@ -170,7 +170,7 @@ class Saxony(Germany):
         return (day, "Repentance Day")
 
     def get_variable_days(self, year):
-        days = super(Saxony, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(self.get_repentance_day(year))
         return days
 

--- a/workalendar/europe/greece.py
+++ b/workalendar/europe/greece.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from workalendar.core import WesternCalendar, OrthodoxMixin
+from ..core import WesternCalendar, OrthodoxMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/hungary.py
+++ b/workalendar/europe/hungary.py
@@ -26,5 +26,5 @@ class Hungary(WesternCalendar, ChristianMixin):
     def get_variable_days(self, year):
         # As of 2017, Good Friday became a holiday
         self.include_good_friday = (year >= 2017)
-        days = super(Hungary, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         return days

--- a/workalendar/europe/hungary.py
+++ b/workalendar/europe/hungary.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from workalendar.core import WesternCalendar, ChristianMixin
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/iceland.py
+++ b/workalendar/europe/iceland.py
@@ -1,8 +1,5 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import date
-from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.core import THU, MON
+from ..core import WesternCalendar, ChristianMixin, THU, MON
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/iceland.py
+++ b/workalendar/europe/iceland.py
@@ -34,7 +34,7 @@ class Iceland(WesternCalendar, ChristianMixin):
         return Iceland.get_nth_weekday_in_month(year, 8, MON)
 
     def get_variable_days(self, year):
-        days = super(Iceland, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend([
             (self.get_first_day_of_summer(year), "First day of summer"),
             (self.get_commerce_day(year), "Commerce Day"),

--- a/workalendar/europe/ireland.py
+++ b/workalendar/europe/ireland.py
@@ -27,7 +27,7 @@ class Ireland(WesternCalendar, ChristianMixin):
 
     def get_variable_days(self, year):
         self.include_whit_monday = (year <= 1973)
-        days = super(Ireland, self).get_variable_days(year)
+        days = super().get_variable_days(year)
 
         # St Patrick's day
         st_patrick = date(year, 3, 17)

--- a/workalendar/europe/ireland.py
+++ b/workalendar/europe/ireland.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import date, timedelta
-from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.core import MON
+
+from ..core import WesternCalendar, ChristianMixin, MON
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/italy.py
+++ b/workalendar/europe/italy.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from workalendar.core import WesternCalendar, ChristianMixin
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/latvia.py
+++ b/workalendar/europe/latvia.py
@@ -46,7 +46,7 @@ class Latvia(WesternCalendar, ChristianMixin):
         return days
 
     def get_variable_days(self, year):
-        days = super(Latvia, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend(self.get_independence_days(year))
         days.extend(self.get_republic_days(year))
         return days

--- a/workalendar/europe/latvia.py
+++ b/workalendar/europe/latvia.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import date
-from workalendar.core import WesternCalendar, ChristianMixin
+
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/lithuania.py
+++ b/workalendar/europe/lithuania.py
@@ -1,8 +1,5 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from workalendar.core import WesternCalendar, ChristianMixin
+from ..core import WesternCalendar, ChristianMixin, SUN
 from ..registry_tools import iso_register
-from workalendar.core import SUN
 
 
 @iso_register('LT')

--- a/workalendar/europe/lithuania.py
+++ b/workalendar/europe/lithuania.py
@@ -36,7 +36,7 @@ class Lithuania(WesternCalendar, ChristianMixin):
         )
 
     def get_variable_days(self, year):
-        days = super(Lithuania, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(self.get_mothers_day(year))
         days.append(self.get_fathers_day(year))
         return days

--- a/workalendar/europe/luxembourg.py
+++ b/workalendar/europe/luxembourg.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import date
-from workalendar.core import WesternCalendar, ChristianMixin
+
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/luxembourg.py
+++ b/workalendar/europe/luxembourg.py
@@ -21,7 +21,7 @@ class Luxembourg(WesternCalendar, ChristianMixin):
     )
 
     def get_fixed_holidays(self, year):
-        days = super(Luxembourg, self).get_fixed_holidays(year)
+        days = super().get_fixed_holidays(year)
         if year > 2018:
             days.append((date(year, 5, 9), "Europe Day"))
 

--- a/workalendar/europe/malta.py
+++ b/workalendar/europe/malta.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from workalendar.core import WesternCalendar, ChristianMixin
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/netherlands.py
+++ b/workalendar/europe/netherlands.py
@@ -38,6 +38,6 @@ class Netherlands(WesternCalendar, ChristianMixin):
                 return date(year, 4, 29), "Queen's day"
 
     def get_variable_days(self, year):
-        days = super(Netherlands, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(self.get_king_queen_day(year))
         return days

--- a/workalendar/europe/netherlands.py
+++ b/workalendar/europe/netherlands.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import date
-from workalendar.core import WesternCalendar, ChristianMixin
+
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/norway.py
+++ b/workalendar/europe/norway.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from workalendar.core import WesternCalendar, ChristianMixin
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/poland.py
+++ b/workalendar/europe/poland.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from workalendar.core import WesternCalendar, ChristianMixin
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/portugal.py
+++ b/workalendar/europe/portugal.py
@@ -21,7 +21,7 @@ class Portugal(WesternCalendar, ChristianMixin):
     )
 
     def get_fixed_holidays(self, year):
-        days = super(Portugal, self).get_fixed_holidays(year)
+        days = super().get_fixed_holidays(year)
         if year > 2015 or year < 2013:
 
             days.append((date(year, 10, 5), "Implantação da República"))
@@ -30,7 +30,7 @@ class Portugal(WesternCalendar, ChristianMixin):
         return days
 
     def get_variable_days(self, year):
-        days = super(Portugal, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         if year > 2015 or year < 2013:
             days.append((self.get_corpus_christi(year), "Corpus Christi"))
         return days

--- a/workalendar/europe/portugal.py
+++ b/workalendar/europe/portugal.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import date
-from workalendar.core import WesternCalendar, ChristianMixin
+
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/romania.py
+++ b/workalendar/europe/romania.py
@@ -47,7 +47,7 @@ class Romania(OrthodoxMixin, WesternCalendar):
         return days
 
     def get_variable_days(self, year):
-        days = super(Romania, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend(self.get_childrens_day(year))
         days.extend(self.get_liberation_day(year))
         return days

--- a/workalendar/europe/romania.py
+++ b/workalendar/europe/romania.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import date
-from workalendar.core import WesternCalendar, OrthodoxMixin
+
+from ..core import WesternCalendar, OrthodoxMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/russia.py
+++ b/workalendar/europe/russia.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from workalendar.core import WesternCalendar
+from ..core import WesternCalendar
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/scotland/__init__.py
+++ b/workalendar/europe/scotland/__init__.py
@@ -65,7 +65,7 @@ class Scotland(WesternCalendar, ChristianMixin):
     include_victoria_day = False
 
     def __init__(self, *args, **kwargs):
-        super(Scotland, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         warnings.warn(
             """
 Please bear in mind that every Scotland (sub)calendar is highly experimental.
@@ -132,7 +132,7 @@ as much care as possible.
             "`include_victoria_day` is not implemented.")
 
     def get_variable_days(self, year):
-        days = super(Scotland, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(self.get_may_day(year))
         if self.include_spring_holiday:
             # This method is included in the spring_holiday mixins
@@ -149,7 +149,7 @@ as much care as possible.
         return days
 
     def get_fixed_holidays(self, year):
-        days = super(Scotland, self).get_fixed_holidays(year)
+        days = super().get_fixed_holidays(year)
         if self.include_saint_andrew:
             days.append((date(year, 11, 30), "Saint Andrew's Day"))
         return days
@@ -292,7 +292,7 @@ class Fife(
     include_saint_andrew = True
 
     def get_variable_days(self, year):
-        days = super(Fife, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         # Special computation rule, Fife has TWO spring holidays
         # 1. First Monday in April
         days.append((
@@ -311,7 +311,7 @@ class Galashiels(SpringHolidayFirstMondayJune, Scotland):
     "Galashiels"
 
     def get_variable_days(self, year):
-        days = super(Galashiels, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         # Adding Braw Lads Gathering, 1st Friday in July
         days.append((
             self.get_nth_weekday_in_month(year, 7, FRI),
@@ -333,7 +333,7 @@ class Hawick(Scotland):
     "Hawick"
 
     def get_variable_days(self, year):
-        days = super(Hawick, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         # Common Riding happens on the FRI after the first MON in June
         first_monday = self.get_nth_weekday_in_month(year, 6, MON)
         friday = first_monday + timedelta(days=4)
@@ -351,7 +351,7 @@ class Inverclyde(LateSummer, Scotland):
     include_easter_monday = True
 
     def get_variable_days(self, year):
-        days = super(Inverclyde, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         # Special computation rule, Inverclyde has TWO spring holidays
         # 1. First Monday in April
         days.append((
@@ -374,7 +374,7 @@ class Inverness(
     "Inverness"
 
     def get_variable_days(self, year):
-        days = super(Inverness, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append((
             self.get_nth_weekday_in_month(year, 2, MON),
             "Winter Holiday (February)"
@@ -400,7 +400,7 @@ class Lanark(Scotland):
     "Lanark"
 
     def get_variable_days(self, year):
-        days = super(Lanark, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         # Lanimer is 2nd THU in June
         days.append((
             self.get_nth_weekday_in_month(year, 6, THU, 2),
@@ -412,7 +412,7 @@ class Lanark(Scotland):
 class Linlithgow(Scotland):
     "Linlithgow"
     def get_variable_days(self, year):
-        days = super(Linlithgow, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         # Linlithgow Marches is on TUE after the 2nd THU in June
         second_thursday = self.get_nth_weekday_in_month(year, 6, THU, 2)
         marches_day = second_thursday + timedelta(days=5)
@@ -426,7 +426,7 @@ class Linlithgow(Scotland):
 class Lochaber(Scotland):
     "Lochaber"
     def get_variable_days(self, year):
-        days = super(Lochaber, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         # Winter holiday is on the last MON of march
         days.append((
             self.get_last_weekday_in_month(year, 3, MON),

--- a/workalendar/europe/scotland/__init__.py
+++ b/workalendar/europe/scotland/__init__.py
@@ -24,8 +24,7 @@ FIXME:
 # necessary to split this module and associated tests
 from datetime import date, timedelta
 import warnings
-from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.core import MON, THU, FRI
+from workalendar.core import WesternCalendar, ChristianMixin, MON, THU, FRI
 from .mixins import (
     SpringHolidayFirstMondayApril,
     SpringHolidaySecondMondayApril,

--- a/workalendar/europe/scotland/mixins/__init__.py
+++ b/workalendar/europe/scotland/mixins/__init__.py
@@ -39,7 +39,7 @@ from .autumn_holiday import (
 )
 
 
-class LateSummer(object):
+class LateSummer:
     def get_variable_days(self, year):
         """
         Add Late Summer holiday (First Monday of September)
@@ -52,7 +52,7 @@ class LateSummer(object):
         return days
 
 
-class BattleStirlingBridge(object):
+class BattleStirlingBridge:
     def get_variable_days(self, year):
         """
         Add Battle of Stirling Bridge holiday (Second Monday of September)
@@ -65,7 +65,7 @@ class BattleStirlingBridge(object):
         return days
 
 
-class AyrGoldCup(object):
+class AyrGoldCup:
     def get_variable_days(self, year):
         days = super().get_variable_days(year)
         # Ayr Gold Cup

--- a/workalendar/europe/scotland/mixins/__init__.py
+++ b/workalendar/europe/scotland/mixins/__init__.py
@@ -44,7 +44,7 @@ class LateSummer(object):
         """
         Add Late Summer holiday (First Monday of September)
         """
-        days = super(LateSummer, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append((
             self.get_nth_weekday_in_month(year, 9, MON),
             "Late Summer Holiday"
@@ -57,7 +57,7 @@ class BattleStirlingBridge(object):
         """
         Add Battle of Stirling Bridge holiday (Second Monday of September)
         """
-        days = super(BattleStirlingBridge, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append((
             self.get_nth_weekday_in_month(year, 9, MON, 2),
             "Battle of Stirling Bridge Holiday"
@@ -67,7 +67,7 @@ class BattleStirlingBridge(object):
 
 class AyrGoldCup(object):
     def get_variable_days(self, year):
-        days = super(AyrGoldCup, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         # Ayr Gold Cup
         gold_cup_friday = self.get_nth_weekday_in_month(year, 9, FRI, 3)
         days.append(

--- a/workalendar/europe/scotland/mixins/autumn_holiday.py
+++ b/workalendar/europe/scotland/mixins/autumn_holiday.py
@@ -4,7 +4,7 @@ Autumn Holiday mixins
 from workalendar.core import MON
 
 
-class AutumHoliday(object):
+class AutumHoliday:
     include_autumn_holiday = True
     autumn_holiday_label = "Autumn Holiday"
 

--- a/workalendar/europe/scotland/mixins/fair_holiday.py
+++ b/workalendar/europe/scotland/mixins/fair_holiday.py
@@ -4,7 +4,7 @@ Fair Holiday mixins
 from workalendar.core import MON, FRI
 
 
-class FairHoliday(object):
+class FairHoliday:
     include_fair_holiday = True
     fair_holiday_label = "Fair Holiday"
 

--- a/workalendar/europe/scotland/mixins/spring_holiday.py
+++ b/workalendar/europe/scotland/mixins/spring_holiday.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from workalendar.core import MON
 
 
-class SpringHoliday(object):
+class SpringHoliday:
     include_spring_holiday = True
 
 

--- a/workalendar/europe/scotland/mixins/victoria_day.py
+++ b/workalendar/europe/scotland/mixins/victoria_day.py
@@ -4,7 +4,7 @@ Victoria Day mixins
 from workalendar.core import MON
 
 
-class VictoriaDayMixin(object):
+class VictoriaDayMixin:
     include_victoria_day = True
     victoria_day_label = "Victoria Day"
 

--- a/workalendar/europe/serbia.py
+++ b/workalendar/europe/serbia.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from workalendar.core import WesternCalendar, OrthodoxMixin
+from ..core import WesternCalendar, OrthodoxMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/slovakia.py
+++ b/workalendar/europe/slovakia.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from workalendar.core import WesternCalendar, ChristianMixin
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/slovenia.py
+++ b/workalendar/europe/slovenia.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import date
-from workalendar.core import WesternCalendar, ChristianMixin
+
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/slovenia.py
+++ b/workalendar/europe/slovenia.py
@@ -26,7 +26,7 @@ class Slovenia(WesternCalendar, ChristianMixin):
     )
 
     def get_variable_days(self, year):
-        days = super(Slovenia, self).get_variable_days(year)
+        days = super().get_variable_days(year)
 
         # From 1955 until May 2012, when the National Assembly of Slovenia
         # passed the Public Finance Balance Act, 2 January was a work-free day.

--- a/workalendar/europe/spain.py
+++ b/workalendar/europe/spain.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from workalendar.core import WesternCalendar, ChristianMixin
+from ..core import WesternCalendar, ChristianMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/sweden.py
+++ b/workalendar/europe/sweden.py
@@ -46,7 +46,7 @@ class Sweden(WesternCalendar, ChristianMixin):
         return all_saints
 
     def get_variable_days(self, year):
-        days = super(Sweden, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append((self.get_midsummer_day(year), "Midsummer's Day"))
         days.append((self.get_midsummer_eve(year), "Midsummer's Eve"))
         days.append((self.get_variable_all_saints(year), "All Saints"))

--- a/workalendar/europe/sweden.py
+++ b/workalendar/europe/sweden.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import date
-from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.core import FRI, SAT
+
+from ..core import WesternCalendar, ChristianMixin, FRI, SAT
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/switzerland.py
+++ b/workalendar/europe/switzerland.py
@@ -46,7 +46,7 @@ class Vaud(Switzerland):
         )
 
     def get_variable_days(self, year):
-        days = super(Vaud, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         if self.include_federal_thanksgiving_monday:
             days.append((self.get_federal_thanksgiving_monday(year),
                          "Federal Thanksgiving Monday"))
@@ -74,6 +74,6 @@ class Geneva(Switzerland):
         )
 
     def get_variable_days(self, year):
-        days = super(Geneva, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(self.get_genevan_fast(year))
         return days

--- a/workalendar/europe/switzerland.py
+++ b/workalendar/europe/switzerland.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import date, timedelta
+
 from ..core import WesternCalendar, ChristianMixin, SUN
 from ..registry_tools import iso_register
 

--- a/workalendar/europe/turkey.py
+++ b/workalendar/europe/turkey.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import timedelta
+
 from ..core import WesternCalendar, IslamicMixin
 from ..registry_tools import iso_register
 

--- a/workalendar/europe/ukraine.py
+++ b/workalendar/europe/ukraine.py
@@ -24,7 +24,7 @@ class Ukraine(OrthodoxMixin, WesternCalendar):
     include_whit_monday = True
 
     def get_variable_days(self, year):
-        days = super(Ukraine, self).get_variable_days(year)
+        days = super().get_variable_days(year)
 
         # Orthodox Christmas holiday is moved when it falls over the week
         orthodox_christmas = date(year, 1, 7)

--- a/workalendar/europe/ukraine.py
+++ b/workalendar/europe/ukraine.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import date
-from workalendar.core import WesternCalendar, OrthodoxMixin
+
+from ..core import WesternCalendar, OrthodoxMixin
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/united_kingdom.py
+++ b/workalendar/europe/united_kingdom.py
@@ -1,8 +1,5 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import date
-from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.core import MON
+from ..core import WesternCalendar, ChristianMixin, MON
 from ..registry_tools import iso_register
 
 

--- a/workalendar/europe/united_kingdom.py
+++ b/workalendar/europe/united_kingdom.py
@@ -64,7 +64,7 @@ class UnitedKingdom(WesternCalendar, ChristianMixin):
         return non_computable
 
     def get_variable_days(self, year):
-        days = super(UnitedKingdom, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(self.get_early_may_bank_holiday(year))
         days.append(self.get_spring_bank_holiday(year))
         days.append(self.get_late_summer_bank_holiday(year))
@@ -82,7 +82,7 @@ class UnitedKingdomNorthernIreland(UnitedKingdom):
     'Northern Ireland'
 
     def get_variable_days(self, year):
-        days = super(UnitedKingdomNorthernIreland, self) \
+        days = super() \
             .get_variable_days(year)
         # St Patrick's day
         st_patrick = date(year, 3, 17)

--- a/workalendar/oceania/__init__.py
+++ b/workalendar/oceania/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .australia import (
     Australia,
     AustralianCapitalTerritory,

--- a/workalendar/oceania/australia.py
+++ b/workalendar/oceania/australia.py
@@ -49,7 +49,7 @@ class Australia(WesternCalendar, ChristianMixin):
 
     def get_variable_days(self, year):
         # usual variable days
-        days = super(Australia, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         january_first = date(year, 1, 1)
         if january_first.weekday() in self.get_weekend_days():
             days.append((
@@ -152,7 +152,7 @@ class AustralianCapitalTerritory(Australia):
             return shift, "Reconciliation Day Shift"
 
     def get_variable_days(self, year):
-        days = super(AustralianCapitalTerritory, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(self.get_canberra_day(year))
 
         family_community_day = self.get_family_community_day(year)
@@ -200,7 +200,7 @@ class NorthernTerritory(Australia):
         )
 
     def get_variable_days(self, year):
-        days = super(NorthernTerritory, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend([
             self.get_may_day(year),
             self.get_picnic_day(year),
@@ -224,7 +224,7 @@ class Queensland(Australia):
         )
 
     def get_variable_days(self, year):
-        days = super(Queensland, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(self.get_labour_day_may(year))
         return days
 
@@ -248,7 +248,7 @@ class SouthAustralia(Australia):
         return (date(year, 12, 26), "Proclamation Day")
 
     def get_variable_days(self, year):
-        days = super(SouthAustralia, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend([
             self.get_adelaides_cup(year),
             self.get_proclamation_day(year),
@@ -280,7 +280,7 @@ class Tasmania(Australia):
         )
 
     def get_variable_days(self, year):
-        days = super(Tasmania, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(self.get_eight_hours_day(year))
         if self.has_recreation_day:
             days.append(self.get_recreation_day(year))
@@ -300,7 +300,7 @@ class Hobart(Tasmania):
         )
 
     def get_variable_days(self, year):
-        days = super(Hobart, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(self.get_hobart(year))
         return days
 
@@ -326,7 +326,7 @@ class Victoria(Australia):
         )
 
     def get_variable_days(self, year):
-        days = super(Victoria, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(self.get_labours_day_in_march(year))
         days.append(self.get_melbourne_cup(year))
         return days
@@ -354,7 +354,7 @@ class WesternAustralia(Australia):
         # The western Australia territory, since it's based on the Governor
         # Decision (it is typically the last Monday of September or the first
         # Monday of October)
-        days = super(WesternAustralia, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(self.get_labours_day_in_march(year))
         days.append(self.get_western_australia_day(year))
         return days

--- a/workalendar/oceania/australia.py
+++ b/workalendar/oceania/australia.py
@@ -1,10 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 from datetime import date, timedelta
 
-from ..core import WesternCalendar, ChristianMixin
-from ..core import MON, TUE, SAT, SUN
+from ..core import WesternCalendar, ChristianMixin, MON, TUE, SAT, SUN
 from ..registry_tools import iso_register
 
 

--- a/workalendar/oceania/marshall_islands.py
+++ b/workalendar/oceania/marshall_islands.py
@@ -14,7 +14,7 @@ class MarshallIslands(WesternCalendar, ChristianMixin):
     include_good_friday = True
 
     def get_variable_days(self, year):
-        days = super(MarshallIslands, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append((
             MarshallIslands.get_nth_weekday_in_month(year, 7, FRI),
             "Fishermen's Holiday"

--- a/workalendar/oceania/marshall_islands.py
+++ b/workalendar/oceania/marshall_islands.py
@@ -1,8 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
-from ..core import WesternCalendar, ChristianMixin
-from ..core import FRI
+from ..core import WesternCalendar, ChristianMixin, FRI
 from ..registry_tools import iso_register
 
 

--- a/workalendar/oceania/new_zealand.py
+++ b/workalendar/oceania/new_zealand.py
@@ -31,7 +31,7 @@ class NewZealand(WesternCalendar, ChristianMixin):
 
     def get_variable_days(self, year):
         # usual variable days
-        days = super(NewZealand, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(self.get_queens_birthday(year))
         days.append(self.get_labour_day(year))
 

--- a/workalendar/oceania/new_zealand.py
+++ b/workalendar/oceania/new_zealand.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 from datetime import date, timedelta
 
-from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.core import MON, SAT, SUN
+from ..core import WesternCalendar, ChristianMixin, MON, SAT, SUN
 from ..registry_tools import iso_register
 
 

--- a/workalendar/registry.py
+++ b/workalendar/registry.py
@@ -5,7 +5,7 @@ from .core import Calendar
 from .exceptions import ISORegistryError
 
 
-class IsoRegistry(object):
+class IsoRegistry:
     """
     Registry for all calendars retrievable
     by ISO 3166-2 codes associated with countries

--- a/workalendar/registry.py
+++ b/workalendar/registry.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 from importlib import import_module
 import warnings
 

--- a/workalendar/registry.py
+++ b/workalendar/registry.py
@@ -33,7 +33,7 @@ class IsoRegistry(object):
         self.region_registry = dict()
         if load_standard_modules:
             for module_name in self.STANDARD_MODULES:
-                module = 'workalendar.{}'.format(module_name)
+                module = f'workalendar.{module_name}'
                 all_classes = getattr(import_module(module), '__all__')
                 self.load_module_from_items(module, all_classes)
 
@@ -43,7 +43,7 @@ class IsoRegistry(object):
         """
         if not issubclass(cls, Calendar):
             raise ISORegistryError(
-                "Class `{}` is not a Calendar class".format(cls)
+                f"Class `{cls}` is not a Calendar class"
             )
         self.region_registry[iso_code] = cls
 
@@ -87,7 +87,7 @@ class IsoRegistry(object):
         """
         items = dict()
         for key, value in self.region_registry.items():
-            if key.startswith("{}-".format(iso_code)):
+            if key.startswith(f"{iso_code}-"):
                 items[key] = value
         return items
 

--- a/workalendar/tests/__init__.py
+++ b/workalendar/tests/__init__.py
@@ -9,7 +9,7 @@ class GenericCalendarTest(TestCase):
     cal_class = Calendar
 
     def setUp(self):
-        super(GenericCalendarTest, self).setUp()
+        super().setUp()
         warnings.simplefilter('ignore')
         self.year = date.today().year
         self.cal = self.cal_class()

--- a/workalendar/tests/test_africa.py
+++ b/workalendar/tests/test_africa.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from datetime import date
 from workalendar.tests import GenericCalendarTest
 from workalendar.africa import (

--- a/workalendar/tests/test_america.py
+++ b/workalendar/tests/test_america.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from datetime import date
 from workalendar.tests import GenericCalendarTest
 from workalendar.america import Colombia, Barbados

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from datetime import date
 from unittest import TestCase
 

--- a/workalendar/tests/test_canada.py
+++ b/workalendar/tests/test_canada.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from datetime import date
 from workalendar.tests import GenericCalendarTest
 from workalendar.america.canada import (

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from datetime import date
 from collections import Counter
 
@@ -457,16 +456,16 @@ class FranceAlsaceMoselleTest(FranceTest):
     cal_class = FranceAlsaceMoselle
 
     def test_year_2013(self):
-        super(FranceAlsaceMoselleTest, self).test_year_2013()
+        super().test_year_2013()
         holidays = self.cal.holidays_set(2013)
         self.assertIn(date(2013, 3, 29), holidays)  # Good friday
         self.assertIn(date(2013, 12, 26), holidays)  # Boxing day
 
     def test_working_days(self):
-        super(FranceAlsaceMoselleTest, self).test_working_days()
+        super().test_working_days()
 
     def test_business_days_computations(self):
-        super(FranceAlsaceMoselleTest, self) \
+        super() \
             .test_business_days_computations()
 
 

--- a/workalendar/tests/test_registry.py
+++ b/workalendar/tests/test_registry.py
@@ -14,7 +14,7 @@ class SubRegionCalendar(Calendar):
     'Sub Region'
 
 
-class NotACalendarClass(object):
+class NotACalendarClass:
     "Not a Calendar"
 
 

--- a/workalendar/tests/test_registry_africa.py
+++ b/workalendar/tests/test_registry_africa.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest import TestCase
 
 from workalendar.africa import (

--- a/workalendar/tests/test_registry_america.py
+++ b/workalendar/tests/test_registry_america.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest import TestCase
 
 from workalendar.america import (

--- a/workalendar/tests/test_registry_asia.py
+++ b/workalendar/tests/test_registry_asia.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest import TestCase
 
 from workalendar.asia import (

--- a/workalendar/tests/test_registry_europe.py
+++ b/workalendar/tests/test_registry_europe.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest import TestCase
 from workalendar.europe import (
     Austria, Belgium, Bulgaria, Croatia, Cyprus, CzechRepublic, Estonia,

--- a/workalendar/tests/test_registry_oceania.py
+++ b/workalendar/tests/test_registry_oceania.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest import TestCase
 
 from workalendar.oceania import (

--- a/workalendar/tests/test_registry_usa.py
+++ b/workalendar/tests/test_registry_usa.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest import TestCase
 from workalendar.usa import (
     UnitedStates,

--- a/workalendar/tests/test_scotland.py
+++ b/workalendar/tests/test_scotland.py
@@ -12,130 +12,130 @@ from workalendar.europe import (
 )
 
 
-class GoodFridayTestMixin(object):
+class GoodFridayTestMixin:
     def test_good_friday(self):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 3, 30), holidays)
 
 
-class EasterMondayTestMixin(object):
+class EasterMondayTestMixin:
     def test_easter_monday(self):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 4, 2), holidays)
 
 
-class SpringHolidayFirstMondayAprilTestMixin(object):
+class SpringHolidayFirstMondayAprilTestMixin:
     def test_spring_holiday(self):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 4, 2), holidays)
 
 
-class SpringHolidaySecondMondayAprilTestMixin(object):
+class SpringHolidaySecondMondayAprilTestMixin:
     def test_spring_holiday(self):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 4, 9), holidays)
 
 
-class SpringHolidayLastMondayMayTestMixin(object):
+class SpringHolidayLastMondayMayTestMixin:
     def test_spring_holiday(self):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 5, 28), holidays)
 
 
-class FairHolidayLastMondayJuneTestMixin(object):
+class FairHolidayLastMondayJuneTestMixin:
     def test_fair_holiday(self):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 6, 25), holidays)
 
 
-class FairHolidayFirstMondayJulyTestMixin(object):
+class FairHolidayFirstMondayJulyTestMixin:
     def test_fair_holiday(self):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 7, 2), holidays)
 
 
-class FairHolidaySecondMondayJulyTestMixin(object):
+class FairHolidaySecondMondayJulyTestMixin:
     def test_fair_holiday(self):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 7, 9), holidays)
 
 
-class FairHolidayThirdMondayJulyTestMixin(object):
+class FairHolidayThirdMondayJulyTestMixin:
     def test_fair_holiday(self):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 7, 16), holidays)
 
 
-class FairHolidayLastMondayJulyTestMixin(object):
+class FairHolidayLastMondayJulyTestMixin:
     def test_fair_holiday(self):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 7, 30), holidays)
 
 
-class FairHolidayFourthFridayJulyTestMixin(object):
+class FairHolidayFourthFridayJulyTestMixin:
     def test_fair_holiday(self):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 7, 27), holidays)
 
 
-class FairHolidayFirstMondayAugustTestMixin(object):
+class FairHolidayFirstMondayAugustTestMixin:
     def test_fair_holiday(self):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 8, 6), holidays)
 
 
-class LateSummerTestMixin(object):
+class LateSummerTestMixin:
     def test_late_summer(self):
         # First monday of september
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 9, 3), holidays)
 
 
-class BattleStirlingBridgeTestMixin(object):
+class BattleStirlingBridgeTestMixin:
     def test_stirling(self):
         # Second monday of september
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 9, 10), holidays)
 
 
-class AutumnHolidayLastMondaySeptemberTestMixin(object):
+class AutumnHolidayLastMondaySeptemberTestMixin:
     def test_autumn_holiday(self):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 9, 24), holidays)
 
 
-class AutumnHolidayFirstMondayOctoberTestMixin(object):
+class AutumnHolidayFirstMondayOctoberTestMixin:
     def test_autumn_holiday(self):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 10, 1), holidays)
 
 
-class AutumnHolidaySecondMondayOctoberTestMixin(object):
+class AutumnHolidaySecondMondayOctoberTestMixin:
     def test_autumn_holiday(self):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 10, 8), holidays)
 
 
-class AutumnHolidayThirdMondayOctoberTestMixin(object):
+class AutumnHolidayThirdMondayOctoberTestMixin:
     def test_autumn_holiday(self):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 10, 15), holidays)
 
 
-class SaintAndrewTestMixin(object):
+class SaintAndrewTestMixin:
     def test_saint_andrew(self):
         # St. Andrew's day happens on November 30th
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 11, 30), holidays)
 
 
-class VictoriaDayLastMondayMayTestMixin(object):
+class VictoriaDayLastMondayMayTestMixin:
     def test_victoria_day(self):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 5, 28), holidays)
 
 
-class SpringHolidayTuesdayAfterFirstMondayMayTestMixin(object):
+class SpringHolidayTuesdayAfterFirstMondayMayTestMixin:
     def test_spring_holiday_2018(self):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 5, 8), holidays)
@@ -145,19 +145,19 @@ class SpringHolidayTuesdayAfterFirstMondayMayTestMixin(object):
         self.assertIn(date(2017, 5, 2), holidays)
 
 
-class VictoriaDayFirstMondayJuneTestMixin(object):
+class VictoriaDayFirstMondayJuneTestMixin:
     def test_victoria_day(self):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 6, 4), holidays)
 
 
-class VictoriaDayFourthMondayMayTestMixin(object):
+class VictoriaDayFourthMondayMayTestMixin:
     def test_victoria_day(self):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 5, 28), holidays)
 
 
-class AyrGoldCupTestMixin(object):
+class AyrGoldCupTestMixin:
     """
     Ayr Gold cup - two holidays for Ayr and Kilmarnock
     """

--- a/workalendar/tests/test_scotland.py
+++ b/workalendar/tests/test_scotland.py
@@ -1,6 +1,5 @@
 from datetime import date
-from unittest import TestCase, skipIf
-import sys
+from unittest import TestCase
 import warnings
 
 from workalendar.tests import GenericCalendarTest
@@ -11,9 +10,6 @@ from workalendar.europe import (
     Lanark, Linlithgow, Lochaber, NorthLanarkshire, Paisley, Perth,
     ScottishBorders, SouthLanarkshire, Stirling, WestDunbartonshire,
 )
-
-
-PY2 = sys.version_info[0] == 2
 
 
 class GoodFridayTestMixin(object):
@@ -275,9 +271,6 @@ class ScotlandTest(GenericCalendarTest):
     """
     cal_class = Scotland
 
-    # For some reason, the Python 2 warnings module doesn't trigger a warning
-    # at each call of constructor ; skipping if we're in a Python2 env.
-    @skipIf(PY2, "Python 2 warnings unsupported")
     def test_init_warning(self):
         warnings.simplefilter("always")
         with warnings.catch_warnings(record=True) as w:

--- a/workalendar/tests/test_turkey.py
+++ b/workalendar/tests/test_turkey.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from datetime import date
 
 from workalendar.tests import GenericCalendarTest

--- a/workalendar/tests/test_usa.py
+++ b/workalendar/tests/test_usa.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest import skip, skipIf
 from datetime import date
 import sys

--- a/workalendar/tests/test_usa.py
+++ b/workalendar/tests/test_usa.py
@@ -212,7 +212,7 @@ class UnitedStatesTest(GenericCalendarTest):
         self.assertNotIn(day, holidays)
 
 
-class NoColumbus(object):
+class NoColumbus:
     """
     Some States don't include Columbus Day:
 
@@ -228,7 +228,7 @@ class NoColumbus(object):
         self.assertNotIn(date(2017, 10, 9), holidays)
 
 
-class NoPresidentialDay(object):
+class NoPresidentialDay:
     """
     Washington's birthday is not included in Delaware calendar.
     """
@@ -240,7 +240,7 @@ class NoPresidentialDay(object):
         self.assertNotIn(day, holidays)
 
 
-class InaugurationDay(object):
+class InaugurationDay:
     """
     When Inauguration Day is a public holiday
     """
@@ -258,7 +258,7 @@ class InaugurationDay(object):
         # NOTE: 1985 is not relevant, it's the same as MLK Day
 
 
-class ElectionDayEvenYears(object):
+class ElectionDayEvenYears:
     """
     Some state include the election day on even years
     """
@@ -278,7 +278,7 @@ class ElectionDayEvenYears(object):
         self.assertNotIn(self.cal.get_election_date(2017), holidays)
 
 
-class ElectionDayPresidentialYears(object):
+class ElectionDayPresidentialYears:
     """
     Some state include the election day on presidential years
     """
@@ -299,7 +299,7 @@ class ElectionDayPresidentialYears(object):
         self.assertNotIn(self.cal.get_election_date(2017), holidays)
 
 
-class ElectionDayEveryYear(object):
+class ElectionDayEveryYear:
     """
     Some State include election day on every year
     """
@@ -310,7 +310,7 @@ class ElectionDayEveryYear(object):
             self.assertIn(self.cal.get_election_date(year), holidays)
 
 
-class IncludeMardiGras(object):
+class IncludeMardiGras:
     """
     Louisiana and some areas (Alabama Counties) include Mardi Gras
     """
@@ -613,7 +613,7 @@ class DistrictOfColumbiaTest(InaugurationDay, UnitedStatesTest):
         self.assertIn(date(2016, 4, 16), holidays)  # Emancipation Day
 
 
-class FloridaBasicTest(object):
+class FloridaBasicTest:
     """
     Core Florida tests.
 

--- a/workalendar/tests/test_usa.py
+++ b/workalendar/tests/test_usa.py
@@ -1,6 +1,5 @@
-from unittest import skip, skipIf
+from unittest import skip
 from datetime import date
-import sys
 import warnings
 
 from workalendar.tests import GenericCalendarTest
@@ -23,8 +22,6 @@ from workalendar.usa import (
     # Other territories, cities...
     AmericanSamoa, ChicagoIllinois, Guam, SuffolkCountyMassachusetts,
 )
-
-PY2 = sys.version_info[0] == 2
 
 
 class UnitedStatesTest(GenericCalendarTest):
@@ -667,7 +664,6 @@ class FloridaLegalTest(IncludeMardiGras, ElectionDayEveryYear,
     """
     cal_class = FloridaLegal
 
-    @skipIf(PY2, "Python 2 warnings unsupported")
     def test_init_warning(self):
         warnings.simplefilter("always")
         with warnings.catch_warnings(record=True) as w:

--- a/workalendar/usa/__init__.py
+++ b/workalendar/usa/__init__.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 from .core import UnitedStates
 
 from .alabama import (

--- a/workalendar/usa/alabama.py
+++ b/workalendar/usa/alabama.py
@@ -36,6 +36,6 @@ class AlabamaPerryCounty(Alabama):
         )
 
     def get_variable_days(self, year):
-        days = super(AlabamaPerryCounty, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(self.get_obama_day(year))
         return days

--- a/workalendar/usa/alabama.py
+++ b/workalendar/usa/alabama.py
@@ -1,9 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
-from .core import UnitedStates
-from ..core import MON
+from .core import UnitedStates, MON
 from ..registry_tools import iso_register
 
 

--- a/workalendar/usa/alaska.py
+++ b/workalendar/usa/alaska.py
@@ -1,9 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
-from .core import UnitedStates
-from workalendar.core import MON
+from .core import UnitedStates, MON
 from ..registry_tools import iso_register
 
 

--- a/workalendar/usa/alaska.py
+++ b/workalendar/usa/alaska.py
@@ -11,7 +11,7 @@ class Alaska(UnitedStates):
     include_columbus_day = False
 
     def get_variable_days(self, year):
-        days = super(Alaska, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(
             (Alaska.get_last_weekday_in_month(year, 3, MON), "Seward's Day")
         )

--- a/workalendar/usa/american_samoa.py
+++ b/workalendar/usa/american_samoa.py
@@ -20,7 +20,7 @@ class AmericanSamoa(UnitedStates):
         )
 
     def get_variable_days(self, year):
-        days = super(AmericanSamoa, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend([
             self.get_flag_day(year),
         ])

--- a/workalendar/usa/american_samoa.py
+++ b/workalendar/usa/american_samoa.py
@@ -1,5 +1,3 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 from datetime import date
 
 from .core import UnitedStates

--- a/workalendar/usa/arizona.py
+++ b/workalendar/usa/arizona.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from .core import UnitedStates
 from ..registry_tools import iso_register
 

--- a/workalendar/usa/arkansas.py
+++ b/workalendar/usa/arkansas.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from .core import UnitedStates
 from ..registry_tools import iso_register
 

--- a/workalendar/usa/california.py
+++ b/workalendar/usa/california.py
@@ -21,7 +21,7 @@ class CaliforniaEducation(California):
 
     def get_variable_days(self, year):
         # usual variable days
-        days = super(CaliforniaEducation, self).get_variable_days(year)
+        days = super().get_variable_days(year)
 
         if year != 2009:
             days.append(self.get_lincoln_birthday(year))

--- a/workalendar/usa/california.py
+++ b/workalendar/usa/california.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from .core import UnitedStates
 from ..core import MON
 from ..registry_tools import iso_register

--- a/workalendar/usa/colorado.py
+++ b/workalendar/usa/colorado.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from .core import UnitedStates
 from ..registry_tools import iso_register
 

--- a/workalendar/usa/connecticut.py
+++ b/workalendar/usa/connecticut.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from .core import UnitedStates
 from ..registry_tools import iso_register
 

--- a/workalendar/usa/core.py
+++ b/workalendar/usa/core.py
@@ -280,7 +280,7 @@ class UnitedStates(WesternCalendar, ChristianMixin):
 
     def get_variable_days(self, year):
         # usual variable days
-        days = super(UnitedStates, self).get_variable_days(year)
+        days = super().get_variable_days(year)
 
         # Martin Luther King's Day started only in 1985
         if year >= 1985:
@@ -347,7 +347,7 @@ class UnitedStates(WesternCalendar, ChristianMixin):
         return (date(year, 11, 11), self.veterans_day_label)
 
     def get_fixed_holidays(self, year):
-        days = super(UnitedStates, self).get_fixed_holidays(year)
+        days = super().get_fixed_holidays(year)
         if self.include_veterans_day:
             days.append(self.get_veterans_day(year))
         return days
@@ -356,6 +356,6 @@ class UnitedStates(WesternCalendar, ChristianMixin):
         """
         Will return holidays and their shifted days
         """
-        days = super(UnitedStates, self).get_calendar_holidays(year)
+        days = super().get_calendar_holidays(year)
         days = self.shift(days, year)
         return days

--- a/workalendar/usa/core.py
+++ b/workalendar/usa/core.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from datetime import date, timedelta
 
 from ..core import WesternCalendar, ChristianMixin

--- a/workalendar/usa/core.py
+++ b/workalendar/usa/core.py
@@ -256,8 +256,7 @@ class UnitedStates(WesternCalendar, ChristianMixin):
         If the year is not a Inauguration Year, it raises a ValueError.
         """
         if ((year - 1) % 4) != 0:
-            raise ValueError(
-                "The year {} is not an Inauguration Year".format(year))
+            raise ValueError(f"The year {year} is not an Inauguration Year")
         inauguration_day = date(year, 1, 20)
         if inauguration_day.weekday() == SUN:
             inauguration_day = date(year, 1, 21)

--- a/workalendar/usa/delaware.py
+++ b/workalendar/usa/delaware.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from .core import UnitedStates
 from ..registry_tools import iso_register
 

--- a/workalendar/usa/district_columbia.py
+++ b/workalendar/usa/district_columbia.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from .core import UnitedStates
 from ..registry_tools import iso_register
 

--- a/workalendar/usa/florida.py
+++ b/workalendar/usa/florida.py
@@ -6,7 +6,7 @@ from .core import UnitedStates
 from ..registry_tools import iso_register
 
 
-class HebrewHolidays(object):
+class HebrewHolidays:
 
     hebrew_calendars = {}
 

--- a/workalendar/usa/florida.py
+++ b/workalendar/usa/florida.py
@@ -89,7 +89,7 @@ class FloridaLegal(Florida):
     include_election_day_every_year = True
 
     def __init__(self, *args, **kwargs):
-        super(FloridaLegal, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         warnings.warn(
             "Florida's laws separate the definitions between paid versus legal"
             " holidays. Be warned that Florida Legal specific Holidays are not"
@@ -115,7 +115,7 @@ class FloridaCircuitCourts(HebrewHolidays, Florida):
     include_good_friday = True
 
     def get_variable_days(self, year):
-        days = super(FloridaCircuitCourts, self).get_variable_days(year)
+        days = super().get_variable_days(year)
 
         days.append((
             self.get_rosh_hashanah(year),

--- a/workalendar/usa/florida.py
+++ b/workalendar/usa/florida.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 from datetime import date, timedelta
 import warnings
 from pyluach.dates import GregorianDate

--- a/workalendar/usa/georgia.py
+++ b/workalendar/usa/georgia.py
@@ -50,7 +50,7 @@ class Georgia(UnitedStates):
         )
 
     def get_variable_days(self, year):
-        days = super(Georgia, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend([
             self.get_robert_lee_birthday(year),
             self.get_washington_birthday_december(year),

--- a/workalendar/usa/georgia.py
+++ b/workalendar/usa/georgia.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import warnings
 from datetime import date
 from ..core import MON, TUE, WED, THU, FRI, SAT

--- a/workalendar/usa/guam.py
+++ b/workalendar/usa/guam.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from .core import UnitedStates
 from ..registry_tools import iso_register
 

--- a/workalendar/usa/hawaii.py
+++ b/workalendar/usa/hawaii.py
@@ -26,6 +26,6 @@ class Hawaii(UnitedStates):
         )
 
     def get_variable_days(self, year):
-        days = super(Hawaii, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(self.get_statehood_day(year))
         return days

--- a/workalendar/usa/hawaii.py
+++ b/workalendar/usa/hawaii.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..core import FRI
 from ..registry_tools import iso_register
 

--- a/workalendar/usa/idaho.py
+++ b/workalendar/usa/idaho.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from .core import UnitedStates
 from ..registry_tools import iso_register
 

--- a/workalendar/usa/illinois.py
+++ b/workalendar/usa/illinois.py
@@ -29,6 +29,6 @@ class ChicagoIllinois(Illinois):
         )
 
     def get_variable_days(self, year):
-        days = super(ChicagoIllinois, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(self.get_pulaski_day(year))
         return days

--- a/workalendar/usa/illinois.py
+++ b/workalendar/usa/illinois.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from .core import UnitedStates
 from ..registry_tools import iso_register
 from ..core import MON

--- a/workalendar/usa/indiana.py
+++ b/workalendar/usa/indiana.py
@@ -60,7 +60,7 @@ class Indiana(UnitedStates):
         )
 
     def get_variable_days(self, year):
-        days = super(Indiana, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend([
             self.get_washington_birthday_december(year),
         ])

--- a/workalendar/usa/indiana.py
+++ b/workalendar/usa/indiana.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import warnings
 from datetime import date
 from ..core import MON, TUE, WED, THU, FRI, SAT

--- a/workalendar/usa/iowa.py
+++ b/workalendar/usa/iowa.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..registry_tools import iso_register
 from .core import UnitedStates
 

--- a/workalendar/usa/kansas.py
+++ b/workalendar/usa/kansas.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from .core import UnitedStates
 from ..registry_tools import iso_register
 

--- a/workalendar/usa/kentucky.py
+++ b/workalendar/usa/kentucky.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from .core import UnitedStates
 from ..registry_tools import iso_register
 

--- a/workalendar/usa/louisiana.py
+++ b/workalendar/usa/louisiana.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from .core import UnitedStates
 from ..registry_tools import iso_register
 

--- a/workalendar/usa/maine.py
+++ b/workalendar/usa/maine.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from .core import UnitedStates
 from ..registry_tools import iso_register
 

--- a/workalendar/usa/maryland.py
+++ b/workalendar/usa/maryland.py
@@ -9,7 +9,7 @@ class Maryland(UnitedStates):
     include_thanksgiving_friday = True
 
     def get_variable_days(self, year):
-        days = super(Maryland, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         if Maryland.is_presidential_year(year):
             days.append(self.get_election_day(year))
         return days

--- a/workalendar/usa/maryland.py
+++ b/workalendar/usa/maryland.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from .core import UnitedStates
 from ..registry_tools import iso_register
 

--- a/workalendar/usa/massachusetts.py
+++ b/workalendar/usa/massachusetts.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from .core import UnitedStates
 from ..registry_tools import iso_register
 

--- a/workalendar/usa/michigan.py
+++ b/workalendar/usa/michigan.py
@@ -14,7 +14,7 @@ class Michigan(UnitedStates):
     include_columbus_day = False
 
     def get_fixed_holidays(self, year):
-        days = super(Michigan, self).get_fixed_holidays(year)
+        days = super().get_fixed_holidays(year)
 
         # New Year's Eve to be added
         new_years_eve = date(year, 12, 31)

--- a/workalendar/usa/michigan.py
+++ b/workalendar/usa/michigan.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from datetime import date
 from ..core import SUN
 from ..registry_tools import iso_register

--- a/workalendar/usa/minnesota.py
+++ b/workalendar/usa/minnesota.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..registry_tools import iso_register
 from .core import UnitedStates
 

--- a/workalendar/usa/mississippi.py
+++ b/workalendar/usa/mississippi.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from .core import UnitedStates
 from ..registry_tools import iso_register
 

--- a/workalendar/usa/missouri.py
+++ b/workalendar/usa/missouri.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from .core import UnitedStates
 from ..registry_tools import iso_register
 

--- a/workalendar/usa/montana.py
+++ b/workalendar/usa/montana.py
@@ -15,4 +15,4 @@ class Montana(UnitedStates):
             "even years, but for some reason some sources are including it "
             "in 2019. Please use with care."
         )
-        return super(Montana, self).get_variable_days(year)
+        return super().get_variable_days(year)

--- a/workalendar/usa/montana.py
+++ b/workalendar/usa/montana.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 import warnings
 
 from .core import UnitedStates

--- a/workalendar/usa/nebraska.py
+++ b/workalendar/usa/nebraska.py
@@ -9,7 +9,7 @@ class Nebraska(UnitedStates):
     include_thanksgiving_friday = True
 
     def get_variable_days(self, year):
-        days = super(Nebraska, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(
             (self.get_last_weekday_in_month(year, 4, FRI), "Arbor Day")
         )

--- a/workalendar/usa/nebraska.py
+++ b/workalendar/usa/nebraska.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..core import FRI
 from ..registry_tools import iso_register
 from .core import UnitedStates

--- a/workalendar/usa/nevada.py
+++ b/workalendar/usa/nevada.py
@@ -11,7 +11,7 @@ class Nevada(UnitedStates):
     include_columbus_day = False
 
     def get_variable_days(self, year):
-        days = super(Nevada, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(
             (self.get_last_weekday_in_month(year, 10, FRI), "Nevada Day")
         )

--- a/workalendar/usa/nevada.py
+++ b/workalendar/usa/nevada.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..core import FRI
 from ..registry_tools import iso_register
 from .core import UnitedStates

--- a/workalendar/usa/new_hampshire.py
+++ b/workalendar/usa/new_hampshire.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..registry_tools import iso_register
 from .core import UnitedStates
 

--- a/workalendar/usa/new_jersey.py
+++ b/workalendar/usa/new_jersey.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..registry_tools import iso_register
 from .core import UnitedStates
 

--- a/workalendar/usa/new_mexico.py
+++ b/workalendar/usa/new_mexico.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..registry_tools import iso_register
 from .core import UnitedStates
 

--- a/workalendar/usa/new_york.py
+++ b/workalendar/usa/new_york.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..registry_tools import iso_register
 from .core import UnitedStates
 

--- a/workalendar/usa/north_carolina.py
+++ b/workalendar/usa/north_carolina.py
@@ -46,6 +46,6 @@ class NorthCarolina(UnitedStates):
             ]
 
     def get_variable_days(self, year):
-        days = super(NorthCarolina, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.extend(self.get_christmas_shifts(year))
         return days

--- a/workalendar/usa/north_carolina.py
+++ b/workalendar/usa/north_carolina.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from datetime import date
 
 from ..core import MON, TUE, WED, THU, FRI, SAT, SUN

--- a/workalendar/usa/north_dakota.py
+++ b/workalendar/usa/north_dakota.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..registry_tools import iso_register
 from .core import UnitedStates
 

--- a/workalendar/usa/ohio.py
+++ b/workalendar/usa/ohio.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..registry_tools import iso_register
 from .core import UnitedStates
 

--- a/workalendar/usa/oklahoma.py
+++ b/workalendar/usa/oklahoma.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..registry_tools import iso_register
 from .core import UnitedStates
 

--- a/workalendar/usa/oregon.py
+++ b/workalendar/usa/oregon.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..registry_tools import iso_register
 from .core import UnitedStates
 

--- a/workalendar/usa/pennsylvania.py
+++ b/workalendar/usa/pennsylvania.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..registry_tools import iso_register
 from .core import UnitedStates
 

--- a/workalendar/usa/rhode_island.py
+++ b/workalendar/usa/rhode_island.py
@@ -10,7 +10,7 @@ class RhodeIsland(UnitedStates):
     include_election_day_even = True
 
     def get_variable_days(self, year):
-        days = super(RhodeIsland, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(
             (self.get_nth_weekday_in_month(year, 8, MON, 2), "Victory Day")
         )

--- a/workalendar/usa/rhode_island.py
+++ b/workalendar/usa/rhode_island.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..core import MON
 from ..registry_tools import iso_register
 from .core import UnitedStates

--- a/workalendar/usa/south_carolina.py
+++ b/workalendar/usa/south_carolina.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..registry_tools import iso_register
 from .core import UnitedStates
 

--- a/workalendar/usa/south_dakota.py
+++ b/workalendar/usa/south_dakota.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..registry_tools import iso_register
 from .core import UnitedStates
 

--- a/workalendar/usa/tennessee.py
+++ b/workalendar/usa/tennessee.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..registry_tools import iso_register
 from .core import UnitedStates
 

--- a/workalendar/usa/texas.py
+++ b/workalendar/usa/texas.py
@@ -34,7 +34,7 @@ Example:
         )
 
         def get_variable_days(self, year):
-            days = super(TexasCustom, self).get_variable_days(year)
+            days = super().get_variable_days(year)
             days.append(
                 (self.get_nth_weekday_in_month(year, 1, 15), "Special Day")
             )
@@ -61,7 +61,7 @@ class TexasBase(UnitedStates):
     include_boxing_day = False
 
     def get_fixed_holidays(self, year):
-        days = super(TexasBase, self).get_fixed_holidays(year)
+        days = super().get_fixed_holidays(year)
         if self.texas_include_confederate_heroes:
             days.append(
                 (date(year, 1, 19), "Confederate Heroes Day")

--- a/workalendar/usa/texas.py
+++ b/workalendar/usa/texas.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Texas module
 ============
@@ -42,9 +41,6 @@ Example:
             return days
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from datetime import date
 
 from ..registry_tools import iso_register

--- a/workalendar/usa/utah.py
+++ b/workalendar/usa/utah.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..registry_tools import iso_register
 from .core import UnitedStates
 

--- a/workalendar/usa/vermont.py
+++ b/workalendar/usa/vermont.py
@@ -12,7 +12,7 @@ class Vermont(UnitedStates):
     include_columbus_day = False
 
     def get_variable_days(self, year):
-        days = super(Vermont, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(
             (self.get_nth_weekday_in_month(year, 3, TUE, 1),
              "Town Meeting Day")

--- a/workalendar/usa/vermont.py
+++ b/workalendar/usa/vermont.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..core import TUE
 from ..registry_tools import iso_register
 from .core import UnitedStates

--- a/workalendar/usa/virginia.py
+++ b/workalendar/usa/virginia.py
@@ -29,7 +29,7 @@ class Virginia(UnitedStates):
     include_thanksgiving_wednesday = True
 
     def get_variable_days(self, year):
-        days = super(Virginia, self).get_variable_days(year)
+        days = super().get_variable_days(year)
         days.append(
             (self.get_nth_weekday_in_month(year, 1, FRI, 3),
              "Lee-Jackson Day")

--- a/workalendar/usa/virginia.py
+++ b/workalendar/usa/virginia.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 """
 Virginia module
 

--- a/workalendar/usa/washington.py
+++ b/workalendar/usa/washington.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..registry_tools import iso_register
 from .core import UnitedStates
 

--- a/workalendar/usa/west_virginia.py
+++ b/workalendar/usa/west_virginia.py
@@ -37,7 +37,7 @@ class WestVirginia(UnitedStates):
     )
 
     def get_fixed_holidays(self, year):
-        days = super(WestVirginia, self).get_fixed_holidays(year)
+        days = super().get_fixed_holidays(year)
         if self.west_virginia_include_christmas_eve:
             days.append(
                 (date(year, 12, 24), "Christmas Eve")

--- a/workalendar/usa/west_virginia.py
+++ b/workalendar/usa/west_virginia.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 """
 West Virginia
 

--- a/workalendar/usa/wisconsin.py
+++ b/workalendar/usa/wisconsin.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..registry_tools import iso_register
 from .core import UnitedStates
 

--- a/workalendar/usa/wyoming.py
+++ b/workalendar/usa/wyoming.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from ..registry_tools import iso_register
 from .core import UnitedStates
 


### PR DESCRIPTION
- [x] remove from __future__
- [x] remove coding headers
- [x] Look after super() methods.
- [x] Relative imports
- [x] class don't need to inherit from object