### PR TITLE
v8.0.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,9 @@
 # CHANGELOG
 
-## master (unreleased)
+## v8.0.0 (2020-01-10)
 
+- **BREAKING CHANGE** Drop Support for Python 2 - EOL January 1st 2020 (#442).
 - Added Ukraine calendar, by @apelloni.
-- Drop Support for Python 2 - EOL January 1st 2020 (#442).
 - Small cleanup in the ``.travis.yml`` file, thx to @Natim.
 
 ### ISO Registry API Change

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## master (unreleased)
+
+Nothing here yet.
+
 ## v8.0.0 (2020-01-10)
 
 - **BREAKING CHANGE** Drop Support for Python 2 - EOL January 1st 2020 (#442).

--- a/README.rst
+++ b/README.rst
@@ -5,9 +5,7 @@ Workalendar
 Overview
 ========
 
-Workalendar is a Python module that offers classes able to handle calendars,
-list legal / religious holidays and gives working-day-related computation
-functions.
+Workalendar is a Python module that offers classes able to handle calendars, list legal / religious holidays and gives working-day-related computation functions.
 
 Status
 ======

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ REQUIREMENTS = [
     'pyluach',
     'setuptools>=1.0',
 ]
-version = '8.0.0'
+version = '8.1.0.dev0'
 __VERSION__ = version
 
 params = dict(

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ REQUIREMENTS = [
     'pyluach',
     'setuptools>=1.0',
 ]
-version = '7.3.0.dev0'
+version = '8.0.0'
 __VERSION__ = version
 
 params = dict(


### PR DESCRIPTION
- **BREAKING CHANGE** Drop Support for Python 2 - EOL January 1st 2020 (#442).
- Added Ukraine calendar, by @apelloni.
- Small cleanup in the ``.travis.yml`` file, thx to @Natim.

**ISO Registry API Change**

- Changes in the ``registry.items()`` method API.
  - This method is aliased to ``get_calendars()``. In a near release, the ``items()`` method will change its purpose.
  - The ``get_calendars()`` method accepts an empty/missing ``region_codes`` argument to retrieve the full registry. Please see the [ISO Registry documentation](https://peopledoc.github.io/workalendar/iso-registry.html) for extensive usage docs (#403, #375).

----


- Commit for the tag:
    - [x] Edit version in setup.py
    - [x] Add version in Changelog.md ; trim things
    - [x] Push & wait for the tests to be green
    - [x] tag me.
    - [x] build sdist + wheel packages (``make package``)
- Back to dev commit:
    - [x] Edit version in setup.py
    - [x] Add the "master / nothing to see here" in Changelog.md
    - [x] Push & wait for the tests to be green
- [x] Merge --ff
- Github stuff
    - [ ] Push tag in Github
    - [ ] Edit release on Github using the changelog.
    - [ ] Delete branch
- [ ] upload release on PyPI using ``twine``
- [ ] (*optional*) Make feeback on the various PR or issues.
