### PR TITLE
China support years as a dynamic warning

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,8 +4,6 @@
 
 - Fix warning in China's holidays to dynamically read supported years.
 
-Nothing here yet.
-
 ## v8.0.2 (2020-01-24)
 
 - Fix several miscalculations in Georgia (USA) calendar (#451).

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Fix warning in China's holidays to dynamically read supported years.
+
 Nothing here yet.
 
 ## v8.0.2 (2020-01-24)

--- a/workalendar/asia/china.py
+++ b/workalendar/asia/china.py
@@ -74,7 +74,11 @@ class China(ChineseNewYearCalendar, WesternCalendar):
                     self.extra_working_days.append(date(year, v[0], v[1]))
 
     def get_calendar_holidays(self, year):
-        warnings.warn("Support 2018, 2019 currently, need update every year.")
+        warnings.warn(
+            "Support {} currently, need update every year.".format(
+                ", ".join(map(str, holidays.keys()))
+            )
+        )
         if year not in holidays.keys():
             msg = "Need configure {} for China.".format(year)
             raise CalendarError(msg)


### PR DESCRIPTION
refs #429

Updates the warning to be dynamic based on supported years.

<!-- if your contribution is a fix -->

- [ ] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*

<!-- Release management

- Commit for the tag:
    - [ ] Edit version in setup.py
    - [ ] Add version in Changelog.md ; trim things
    - [ ] Push & wait for the tests to be green
    - [ ] tag me.
    - [ ] build sdist + wheel packages (``make package``)
- Back to dev commit:
    - [ ] Edit version in setup.py
    - [ ] Add the "master / nothing to see here" in Changelog.md
    - [ ] Push & wait for the tests to be green
- [ ] Merge --ff
- Github stuff
    - [ ] Push tag in Github
    - [ ] Edit release on Github using the changelog.
    - [ ] Delete branch
- [ ] upload release on PyPI using ``twine``
- [ ] (*optional*) Make feeback on the various PR or issues.

 -->
