### PR TITLE
China support years as a dynamic warning

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - Added Israel holidays eves and removed holidays which are not affecting the working days in Israel (#461).
+- Fix warning in China's holidays to dynamically read supported years.
 
 ## v8.0.2 (2020-01-24)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 ## master (unreleased)
 
 - Added Israel holidays eves and removed holidays which are not affecting the working days in Israel (#461).
-- Fix warning in China's holidays to dynamically read supported years.
+- Fix warning in China's holidays to dynamically read supported years, thx @fredrike (#459).
 
 ## v8.0.2 (2020-01-24)
 

--- a/workalendar/asia/china.py
+++ b/workalendar/asia/china.py
@@ -74,9 +74,11 @@ class China(ChineseNewYearCalendar, WesternCalendar):
                     self.extra_working_days.append(date(year, v[0], v[1]))
 
     def get_calendar_holidays(self, year):
+        year_min, year_max = min(holidays.keys()), max(holidays.keys())
         warnings.warn(
-            "Support {} currently, need update every year.".format(
-                ", ".join(map(str, holidays.keys()))
+            "Support years {}-{} currently, need update every year.".format(
+                year_min,
+                year_max,
             )
         )
         if year not in holidays.keys():

--- a/workalendar/asia/china.py
+++ b/workalendar/asia/china.py
@@ -74,7 +74,11 @@ class China(ChineseNewYearCalendar, WesternCalendar):
                     self.extra_working_days.append(date(year, v[0], v[1]))
 
     def get_calendar_holidays(self, year):
-        warnings.warn("Support 2018, 2019 currently, need update every year.")
+        warnings.warn(
+            "Support {} currently, need update every year.".format(
+                ", ".join(map(str, holidays.keys()))
+            )
+        )
         if year not in holidays.keys():
             msg = "Need configure {} for China.".format(year)
             raise CalendarError(msg)

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from datetime import date
 from . import GenericCalendarTest
 
@@ -66,6 +67,14 @@ class ChinaTest(GenericCalendarTest):
         with self.assertRaises(CalendarError):
             self.cal.holidays_set(2018)
         china_holidays[2018] = save_2018
+
+    def test_warning(self):
+        year = date.today().year
+        with patch('warnings.warn') as patched:
+            self.cal.get_calendar_holidays(year)
+        patched.assert_called_with(
+            'Support years 2018-2020 currently, need update every year.'
+        )
 
     def test_is_working_day(self):
         # It's a SAT, but it's a working day this year


### PR DESCRIPTION
This PR completes, and thus, closes #459.

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
