### PR TITLE
Refactor BrazilBankCalendar to use `include_*` flags

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Added BrazilBankCalendar to support `include_` flags and make it possible to extend and change these flags to support custom bank calendars.
 
 ## v8.2.0 (2020-03-13)
 

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -583,9 +583,11 @@ class BrazilBankCalendar(Brazil):
     Calendar that considers only working days for bank transactions
     for companies and the general public
     """
-    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
-        (12, 25, "Christmas Day"),
-    )
+    include_good_friday = True
+    include_ash_wednesday = True
+    include_corpus_christi = True
+    include_consciencia_negra = False
+    include_easter_sunday = False
 
     def get_last_day_of_year_for_only_internal_bank_trans(self, year):
         """
@@ -607,18 +609,13 @@ class BrazilBankCalendar(Brazil):
         Define the brazilian variable holidays and the last
         day for only internal bank transactions
         """
+        days = super().get_variable_days(year)
         tuesday_carnaval = self.get_carnaval(year)
         monday_carnaval = tuesday_carnaval - timedelta(days=1)
-        good_friday = self.get_good_friday(year)
-        corpus_christi = self.get_corpus_christi(year)
-        ash_wednesday = self.get_ash_wednesday(year)
 
-        non_fixed_holidays = [
+        carnaval_days = [
             (monday_carnaval, "Monday carnaval"),
             (tuesday_carnaval, "Tuesday carnaval"),
-            (good_friday, "Good friday"),
-            (corpus_christi, "Corpus Christi"),
-            (ash_wednesday, "Ash Wednesday"),
         ]
 
         non_working_days = [
@@ -628,7 +625,7 @@ class BrazilBankCalendar(Brazil):
             )
         ]
 
-        return non_fixed_holidays + non_working_days
+        return days + carnaval_days + non_working_days
 
     def find_following_working_day(self, day):
         """

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -815,6 +815,7 @@ class BrazilBankCalendarTest(BrazilTest):
         self.assertIn(date(2017, 1, 1), holidays)  # New year
         self.assertIn(date(2017, 2, 27), holidays)  # Monday carnaval
         self.assertIn(date(2017, 2, 28), holidays)  # Tuesday carnaval
+        self.assertIn(date(2017, 3, 1), holidays)  # Ash wednesday
         self.assertIn(date(2017, 4, 14), holidays)  # Good friday
         self.assertIn(date(2017, 4, 21), holidays)  # Tiradentes
         self.assertIn(date(2017, 5, 1), holidays)  # Labour day
@@ -824,6 +825,8 @@ class BrazilBankCalendarTest(BrazilTest):
         self.assertIn(date(2017, 11, 2), holidays)  # All Souls' Day
         self.assertIn(date(2017, 11, 15), holidays)  # Republic day
         self.assertIn(date(2017, 12, 25), holidays)  # Christmas Day
+        self.assertIn(date(2017, 12, 29), holidays)  # Last working day of year
+        self.assertEquals(14, len(holidays))
 
     def test_year_2017_find_next_working_day_for_new_year(self):
         new_year = date(2017, 1, 1)


### PR DESCRIPTION
It is really useful to allow reuse of this class. Brazilian bank calendar is not always the same.

For my use case, I just want to remove ash wednesday, but for that I have to override `get_variable_days()`.

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*

Related #474