### PR TITLE
Fix argentina holiday names shift 2020

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - Fixed Argentina's "Malvinas Day" date for 2020, shifted to March 31st because of the coronavirus crisis (#476).
+- Fixed Argentina's label for "Malvinas Day" (#476).
 
 ## v8.2.1 (2020-04-03)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 ## master (unreleased)
 
 - Fixed Argentina's "Malvinas Day" date for 2020, shifted to March 31st because of the coronavirus crisis (#476).
-- Fixed Argentina's label for "Malvinas Day" (#476).
+- Fixed Argentina's label for "Malvinas Day" and "Día de la Memoria" (#476).
 
 ## v8.2.1 (2020-04-03)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Fixed Argentina's "Malvinas Day" date for 2020, shifted to March 31st because of the coronavirus crisis (#476).
 
 ## v8.2.1 (2020-04-03)
 

--- a/workalendar/america/argentina.py
+++ b/workalendar/america/argentina.py
@@ -17,38 +17,12 @@ class Argentina(WesternCalendar, ChristianMixin):
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (3, 24, "Día de la Memoria"),
-        (4, 2, "Día de las Malvinas"),
         (5, 1, "Día del Trabajador"),
         (5, 25, "Día de la Revolución de Mayo"),
         (6, 20, "Día Paso a la Inmortalidad del General Manuel Belgrano"),
         (7, 9, "Día de la Independencia"),
         (12, 8, "Día de la Inmaculada Concepción de María"),
     )
-
-    def get_variable_days(self, year):
-
-        days = super().get_variable_days(year)
-        days.append(
-            (self.get_easter_sunday(year) - timedelta(days=48),
-                "Carnival Lunes"))
-
-        days.append(
-            (self.get_easter_sunday(year) - timedelta(days=47),
-                "Carnival"))
-
-        days.append(
-            (self.get_general_guemes_day(year)))
-
-        days.append(
-            (self.get_general_martin_day(year)))
-
-        days.append(
-            (self.get_soberania_day(year)))
-
-        days.append(
-            (self.get_diversidad_day(year)))
-
-        return days
 
     def get_general_guemes_day(self, year):
         """
@@ -131,3 +105,48 @@ class Argentina(WesternCalendar, ChristianMixin):
 
         return (diversidad_day,
                 "Día del Respeto a la Diversidad Cultural")
+
+    def get_malvinas_day(self, year):
+        """
+        Día de las Malvinas
+
+        In honour of the Veterans and the Fallen of the Malvinas war.
+        https://en.wikipedia.org/wiki/Malvinas_Day
+
+        In 2020, it was shifted to March 31st because of
+        the coronavirus crisis.
+        """
+        label = "Día de las Malvinas"
+        if year == 2020:
+            day = date(year, 3, 31)
+        else:
+            day = date(year, 4, 2)
+        return (day, label)
+
+    def get_variable_days(self, year):
+
+        days = super().get_variable_days(year)
+        days.append(
+            (self.get_easter_sunday(year) - timedelta(days=48),
+                "Carnival Lunes"))
+
+        days.append(
+            (self.get_easter_sunday(year) - timedelta(days=47),
+                "Carnival"))
+
+        days.append(
+            self.get_malvinas_day(year))
+
+        days.append(
+            (self.get_general_guemes_day(year)))
+
+        days.append(
+            (self.get_general_martin_day(year)))
+
+        days.append(
+            (self.get_soberania_day(year)))
+
+        days.append(
+            (self.get_diversidad_day(year)))
+
+        return days

--- a/workalendar/america/argentina.py
+++ b/workalendar/america/argentina.py
@@ -116,7 +116,7 @@ class Argentina(WesternCalendar, ChristianMixin):
         In 2020, it was shifted to March 31st because of
         the coronavirus crisis.
         """
-        label = "Día de las Malvinas"
+        label = "Día del Veterano y de los Caídos en la Guerra de Malvinas"
         if year == 2020:
             day = date(year, 3, 31)
         else:

--- a/workalendar/america/argentina.py
+++ b/workalendar/america/argentina.py
@@ -16,7 +16,7 @@ class Argentina(WesternCalendar, ChristianMixin):
     include_christmas = True
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (3, 24, "Día de la Memoria"),
+        (3, 24, "Día Nacional de la Memoria por la Verdad y la Justicia"),
         (5, 1, "Día del Trabajador"),
         (5, 25, "Día de la Revolución de Mayo"),
         (6, 20, "Día Paso a la Inmortalidad del General Manuel Belgrano"),

--- a/workalendar/tests/test_america.py
+++ b/workalendar/tests/test_america.py
@@ -102,6 +102,13 @@ class ArgentinaTest(GenericCalendarTest):
         # The day before
         self.assertIn(date(2021, 10, 11), holidays)
 
+    def test_dia_malvinas_label(self):
+        _, label = self.cal.get_malvinas_day(2020)
+        self.assertEqual(
+            label,
+            "Día del Veterano y de los Caídos en la Guerra de Malvinas"
+        )
+
 
 class ChileTest(GenericCalendarTest):
     cal_class = Chile

--- a/workalendar/tests/test_america.py
+++ b/workalendar/tests/test_america.py
@@ -109,6 +109,15 @@ class ArgentinaTest(GenericCalendarTest):
             "Día del Veterano y de los Caídos en la Guerra de Malvinas"
         )
 
+    def test_dia_memoria_label(self):
+        holidays = self.cal.holidays(2020)
+        holidays = dict(holidays)
+        label_memoria = holidays[date(2020, 3, 24)]
+        self.assertEqual(
+            label_memoria,
+            "Día Nacional de la Memoria por la Verdad y la Justicia"
+        )
+
 
 class ChileTest(GenericCalendarTest):
     cal_class = Chile

--- a/workalendar/tests/test_america.py
+++ b/workalendar/tests/test_america.py
@@ -70,7 +70,12 @@ class ArgentinaTest(GenericCalendarTest):
         self.assertIn(date(2020, 2, 24), holidays)
         self.assertIn(date(2020, 2, 25), holidays)
         self.assertIn(date(2020, 3, 24), holidays)
-        self.assertIn(date(2020, 4, 2), holidays)
+        # Special case: Argentina has shifted this holiday due to
+        # Coronavirus lockdown in 2020.
+        self.assertNotIn(date(2020, 4, 2), holidays)
+        self.assertIn(date(2020, 3, 31), holidays)
+
+        # Back to normal, I hope...
         self.assertIn(date(2020, 4, 10), holidays)
         self.assertIn(date(2020, 5, 1), holidays)
         self.assertIn(date(2020, 5, 25), holidays)


### PR DESCRIPTION
refs #476

* Fixed Argentina's "Malvinas Day" date for 2020, shifted to March 31st because of the coronavirus crisis.
* Fixed Argentina's label for "Malvinas Day" and "Día de la Memoria".

Checklist:

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes.
