### PR TITLE
Rename all shifted days to " Shift" for consistency

### DIFF
--- a/workalendar/africa/south_africa.py
+++ b/workalendar/africa/south_africa.py
@@ -124,7 +124,7 @@ class SouthAfrica(WesternCalendar, ChristianMixin):
             if holiday.weekday() == SUN:
                 days.append((
                     holiday + timedelta(days=1),
-                    "%s substitute" % label
+                    "%s Shift" % label
                 ))
 
         # Other one-offs. Don't shift these

--- a/workalendar/america/barbados.py
+++ b/workalendar/america/barbados.py
@@ -51,6 +51,6 @@ class Barbados(WesternCalendar, ChristianMixin):
         for day, label in days_to_shift:
             if day.weekday() == SUN:
                 days.append(
-                    (day + timedelta(days=1), "%s %s" % (label, "(shifted)"))
+                    (day + timedelta(days=1), "%s %s" % (label, "Shift"))
                 )
         return days

--- a/workalendar/america/canada.py
+++ b/workalendar/america/canada.py
@@ -69,10 +69,10 @@ class BoxingDayMixin(Calendar):
         boxingday = date(year, 12, 26)
         if boxingday.weekday() == MON:
             days = [(boxingday, "Boxing Day"), (date(year, 12, 27),
-                    "Boxing Day (Shift)")]
+                    "Boxing Day Shift")]
         elif boxingday.weekday() == SAT or boxingday.weekday() == SUN:
             days = [(boxingday, "Boxing Day"), (date(year, 12, 28),
-                    "Boxing Day (Shift)")]
+                    "Boxing Day Shift")]
         else:
             days = [(boxingday, "Boxing Day")]
         return days
@@ -86,7 +86,7 @@ class StJeanBaptisteMixin(Calendar):
         if stjean.weekday() in self.get_weekend_days():
             days = [(stjean, "St Jean Baptiste"),
                     (self.find_following_working_day(stjean),
-                     "St Jean Baptiste (Shift)")]
+                     "St Jean Baptiste Shift")]
         else:
             days = [(stjean, "St Jean Baptiste")]
         return days
@@ -99,7 +99,7 @@ class RemembranceDayShiftMixin(Calendar):
         if remembranceday.weekday() in self.get_weekend_days():
             days = [(remembranceday, "Remembrance Day"),
                     (self.find_following_working_day(remembranceday),
-                    "Remembrance Day (Shift)")]
+                    "Remembrance Day Shift")]
         else:
             days = [(remembranceday, "Remembrance Day")]
         return days
@@ -338,5 +338,5 @@ class Nunavut(Canada, VictoriaDayMixin, ThanksgivingMixin,
         nuvanutday = date(year, 7, 9)
         days.append((nuvanutday, "Nuvanut Day"))
         if nuvanutday.weekday() == SUN:
-            days.append((date(year, 7, 10), "Nuvanut Day (Shift)"))
+            days.append((date(year, 7, 10), "Nuvanut Day Shift"))
         return days

--- a/workalendar/america/mexico.py
+++ b/workalendar/america/mexico.py
@@ -35,11 +35,11 @@ class Mexico(WesternCalendar, ChristianMixin):
         # If it's on a Saturday, the Friday is off
         for day, label in days:
             if day.weekday() == SAT:
-                days.append((day - timedelta(days=1), "%s substitute" % label))
+                days.append((day - timedelta(days=1), "%s Shift" % label))
             elif day.weekday() == SUN:
-                days.append((day + timedelta(days=1), "%s substitute" % label))
+                days.append((day + timedelta(days=1), "%s Shift" % label))
         # Extra: if new year's day is a saturday, the friday before is off
         next_new_year = date(year + 1, 1, 1)
         if next_new_year.weekday():
-            days.append((date(year, 12, 31), "New Year Day substitute"))
+            days.append((date(year, 12, 31), "New Year Day Shift"))
         return days

--- a/workalendar/asia/hong_kong.py
+++ b/workalendar/asia/hong_kong.py
@@ -64,7 +64,7 @@ class HongKong(WesternCalendar, ChineseNewYearCalendar, ChristianMixin):
         for day, label in days:
             if day.weekday() == SUN:
                 shifts.append((
-                    day + timedelta(days=1), "{} (shift)".format(label)
+                    day + timedelta(days=1), "{} Shift".format(label)
                 ))
         # Special case for Boxing Day.
         # If Christmas day is on SUN, the December 27th is also a holiday

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -540,7 +540,7 @@ class WesternCalendar(Calendar):
             if new_year.weekday() in self.get_weekend_days():
                 days.append((
                     self.find_following_working_day(new_year),
-                    "New Year shift"))
+                    "New Year Shift"))
         return days
 
 
@@ -658,7 +658,7 @@ class ChineseNewYearCalendar(LunarCalendar):
             if holiday.weekday() == SUN:
                 yield (
                     holiday + timedelta(days=1),
-                    label + ' shift'
+                    label + ' Shift'
                 )
 
     def get_calendar_holidays(self, year):

--- a/workalendar/europe/ireland.py
+++ b/workalendar/europe/ireland.py
@@ -34,7 +34,7 @@ class Ireland(WesternCalendar, ChristianMixin):
         if st_patrick.weekday() in self.get_weekend_days():
             days.append((
                 self.find_following_working_day(st_patrick),
-                "Saint Patrick substitute"))
+                "Saint Patrick Shift"))
 
         # May Day
         if year >= 1994:

--- a/workalendar/europe/united_kingdom.py
+++ b/workalendar/europe/united_kingdom.py
@@ -89,7 +89,7 @@ class UnitedKingdomNorthernIreland(UnitedKingdom):
         if st_patrick.weekday() in self.get_weekend_days():
             days.append((
                 self.find_following_working_day(st_patrick),
-                "Saint Patrick substitute"))
+                "Saint Patrick Shift"))
 
         # Battle of boyne
         battle_of_boyne = date(year, 7, 12)
@@ -97,5 +97,5 @@ class UnitedKingdomNorthernIreland(UnitedKingdom):
         if battle_of_boyne.weekday() in self.get_weekend_days():
             days.append((
                 self.find_following_working_day(battle_of_boyne),
-                "Battle of the Boyne substitute"))
+                "Battle of the Boyne Shift"))
         return days

--- a/workalendar/oceania/australia.py
+++ b/workalendar/oceania/australia.py
@@ -55,14 +55,14 @@ class Australia(WesternCalendar, ChristianMixin):
         if january_first.weekday() in self.get_weekend_days():
             days.append((
                 self.find_following_working_day(january_first),
-                "New Year's Day shift")
+                "New Year's Day Shift")
             )
 
         australia_day = date(year, 1, 26)
         if australia_day.weekday() in self.get_weekend_days():
             days.append((
                 self.find_following_working_day(australia_day),
-                "Australia Day shift")
+                "Australia Day Shift")
             )
 
         # was fixed, but might be shifted

--- a/workalendar/tests/test_africa.py
+++ b/workalendar/tests/test_africa.py
@@ -94,7 +94,7 @@ class SouthAfricaTest(GenericCalendarTest):
         # Since the Founders' day is a Sunday, the same date appears twice
         # The second one is a substitute
         holidays = [item for item in holidays
-                    if item[1] != "Founder's Day substitute"]
+                    if item[1] != "Founder's Day Shift"]
         easter_monday_1980 = date(1980, 4, 7)
         holidays_dates = [item[0] for item in holidays]
         self.assertEqual(holidays_dates.count(easter_monday_1980), 1, holidays)

--- a/workalendar/tests/test_america.py
+++ b/workalendar/tests/test_america.py
@@ -288,7 +288,7 @@ class BarbadosTest(GenericCalendarTest):
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 1, 1), holidays)
         self.assertIn(date(2018, 1, 21), holidays)  # Errol Barrow Day
-        self.assertIn(date(2018, 1, 22), holidays)  # Errol Barrow Day (shift)
+        self.assertIn(date(2018, 1, 22), holidays)  # Errol Barrow Day Shift
         self.assertIn(date(2018, 3, 30), holidays)  # Good Friday
         self.assertIn(date(2018, 4, 1), holidays)  # Easter Sunday
         self.assertIn(date(2018, 4, 2), holidays)  # Easter Monday

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -111,14 +111,14 @@ class HongKongTest(GenericCalendarTest):
         # https://www.gov.hk/en/about/abouthk/holiday/2010.htm
         holidays = self.cal.holidays_set(2010)
         self.assertIn(date(2010, 1, 1), holidays)    # New Year
-        self.assertIn(date(2010, 2, 13), holidays)   # Chinese new year (shift)
+        self.assertIn(date(2010, 2, 13), holidays)   # Chinese new year Shift
         self.assertIn(date(2010, 2, 15), holidays)   # Chinese new year
         self.assertIn(date(2010, 2, 16), holidays)   # Chinese new year
         self.assertNotIn(date(2010, 2, 17), holidays)  # Not Chinese new year
         self.assertIn(date(2010, 4, 2), holidays)    # Good Friday
         self.assertIn(date(2010, 4, 3), holidays)    # Day after Good Friday
         self.assertIn(date(2010, 4, 5), holidays)    # Easter Monday
-        self.assertIn(date(2010, 4, 6), holidays)    # Ching Ming (shifted)
+        self.assertIn(date(2010, 4, 6), holidays)    # Ching Ming Shift
         self.assertIn(date(2010, 5, 1), holidays)    # Labour Day
         self.assertIn(date(2010, 5, 21), holidays)   # Buddha's Birthday
         self.assertIn(date(2010, 6, 16), holidays)   # Tuen Ng Festival
@@ -127,7 +127,7 @@ class HongKongTest(GenericCalendarTest):
         self.assertIn(date(2010, 10, 1), holidays)   # National Day
         self.assertIn(date(2010, 10, 16), holidays)  # Chung Yeung Festival
         self.assertIn(date(2010, 12, 25), holidays)  # Christmas Day
-        self.assertIn(date(2010, 12, 27), holidays)  # Boxing Day (shifted)
+        self.assertIn(date(2010, 12, 27), holidays)  # Boxing Day Shift
 
     def test_year_2013(self):
         # https://www.gov.hk/en/about/abouthk/holiday/2013.htm
@@ -162,7 +162,7 @@ class HongKongTest(GenericCalendarTest):
         self.assertIn(date(2016, 3, 28), holidays)   # Easter Monday
         self.assertIn(date(2016, 4, 4), holidays)    # Ching Ming
         self.assertIn(date(2016, 5, 1), holidays)    # Labour Day (SUN)
-        self.assertIn(date(2016, 5, 2), holidays)    # Labour Day (shifted)
+        self.assertIn(date(2016, 5, 2), holidays)    # Labour Day Shift
         self.assertIn(date(2016, 5, 14), holidays)   # Buddha's Birthday
         self.assertIn(date(2016, 6, 9), holidays)    # Tuen Ng Festival
         self.assertIn(date(2016, 7, 1), holidays)    # HK SAR Establishment Day
@@ -176,7 +176,7 @@ class HongKongTest(GenericCalendarTest):
     def test_year_2017(self):
         # https://www.gov.hk/en/about/abouthk/holiday/2017.htm
         holidays = self.cal.holidays_set(2017)
-        self.assertIn(date(2017, 1, 2), holidays)    # New Year (shifted)
+        self.assertIn(date(2017, 1, 2), holidays)    # New Year Shift
         self.assertIn(date(2017, 1, 28), holidays)   # Chinese new year
         self.assertIn(date(2017, 1, 30), holidays)   # Chinese new year
         self.assertIn(date(2017, 1, 31), holidays)   # Chinese new year
@@ -188,7 +188,7 @@ class HongKongTest(GenericCalendarTest):
         self.assertIn(date(2017, 5, 3), holidays)    # Buddha's Birthday
         self.assertIn(date(2017, 5, 30), holidays)   # Tuen Ng Festival
         self.assertIn(date(2017, 7, 1), holidays)    # HK SAR Establishment Day
-        self.assertIn(date(2017, 10, 2), holidays)   # National Day (shifted)
+        self.assertIn(date(2017, 10, 2), holidays)   # National Day Shift
         self.assertIn(date(2017, 10, 5), holidays)   # Day after Mid-Autumn
         self.assertIn(date(2017, 10, 28), holidays)  # Chung Yeung Festival
         self.assertIn(date(2017, 12, 25), holidays)  # Christmas Day
@@ -214,7 +214,7 @@ class HongKongTest(GenericCalendarTest):
     def test_holidays_2020(self):
         # https://www.gov.hk/en/about/abouthk/holiday/2020.htm
         holidays = self.cal.holidays_set(2020)
-        self.assertIn(date(2020, 1, 1), holidays)    # New Year (shifted)
+        self.assertIn(date(2020, 1, 1), holidays)    # New Year Shift
         self.assertIn(date(2020, 1, 25), holidays)   # Chinese new year
         self.assertIn(date(2020, 1, 27), holidays)   # Chinese new year
         self.assertIn(date(2020, 1, 28), holidays)   # Chinese new year

--- a/workalendar/tests/test_canada.py
+++ b/workalendar/tests/test_canada.py
@@ -20,8 +20,8 @@ class CanadaTest(GenericCalendarTest):
 
     def test_holidays_2012(self):
         holidays = self.cal.holidays_set(2012)
-        self.assertIn(date(2012, 1, 2), holidays)  # New years shift
-        self.assertIn(date(2012, 7, 2), holidays)  # Canada day shift
+        self.assertIn(date(2012, 1, 2), holidays)  # New years Shift
+        self.assertIn(date(2012, 7, 2), holidays)  # Canada day Shift
         self.assertIn(date(2012, 9, 3), holidays)  # Labour day
         self.assertIn(date(2012, 12, 25), holidays)
 
@@ -44,8 +44,8 @@ class OntarioTest(GenericCalendarTest):
 
     def test_holidays_2010(self):
         holidays = self.cal.holidays_set(2010)
-        self.assertIn(date(2010, 12, 27), holidays)  # Christmas day shift
-        self.assertIn(date(2010, 12, 28), holidays)  # Boxing day shift
+        self.assertIn(date(2010, 12, 27), holidays)  # Christmas day Shift
+        self.assertIn(date(2010, 12, 28), holidays)  # Boxing day Shift
 
     def test_holidays_2011(self):
         holidays = self.cal.holidays_set(2011)
@@ -59,7 +59,7 @@ class OntarioTest(GenericCalendarTest):
         self.assertIn(date(2011, 9, 5), holidays)  # Labour Day
         self.assertIn(date(2011, 10, 10), holidays)  # Canadian Thanksgiving
         self.assertIn(date(2011, 12, 26), holidays)
-        self.assertIn(date(2011, 12, 27), holidays)  # Boxing day shift
+        self.assertIn(date(2011, 12, 27), holidays)  # Boxing day Shift
 
     def test_holidays_2012(self):
         holidays = self.cal.holidays_set(2012)
@@ -160,7 +160,7 @@ class SaskatchewanTest(GenericCalendarTest):
         self.assertIn(date(2012, 8, 6), holidays)  # Civic Holiday
         self.assertIn(date(2012, 10, 8), holidays)  # Canadian Thanksgiving
         self.assertIn(date(2012, 11, 11), holidays)  # Remembrance Day
-        self.assertIn(date(2012, 11, 12), holidays)  # Remembrance Day (Shift)
+        self.assertIn(date(2012, 11, 12), holidays)  # Remembrance Day Shift
         self.assertIn(date(2012, 12, 25), holidays)  # Christmas day
 
 

--- a/workalendar/usa/michigan.py
+++ b/workalendar/usa/michigan.py
@@ -26,7 +26,7 @@ class Michigan(UnitedStates):
         xmas_eve = date(year, 12, 24)
         if xmas_eve.weekday() == SUN:
             days.append(
-                (date(year, 12, 22), "Christmas Eve shift")
+                (date(year, 12, 22), "Christmas Eve Shift")
             )
             days.append(
                 (date(year, 12, 29), "New Years Eve Shift")

--- a/workalendar/usa/north_carolina.py
+++ b/workalendar/usa/north_carolina.py
@@ -28,21 +28,21 @@ class NorthCarolina(UnitedStates):
             return []
         if xmas.weekday() == FRI:
             return [
-                (date(year, 12, 28), "Boxing day shift"),
+                (date(year, 12, 28), "Boxing day Shift"),
             ]
         elif xmas.weekday() == SAT:
             return [
-                (date(year, 12, 23), "Christmas Eve shift"),
-                (date(year, 12, 27), "Boxing Day shift"),
+                (date(year, 12, 23), "Christmas Eve Shift"),
+                (date(year, 12, 27), "Boxing Day Shift"),
             ]
         elif xmas.weekday() == SUN:
             return [
-                (date(year, 12, 23), "Christmas Eve shift"),
-                (date(year, 12, 27), "Boxing Day shift"),
+                (date(year, 12, 23), "Christmas Eve Shift"),
+                (date(year, 12, 27), "Boxing Day Shift"),
             ]
         elif xmas.weekday() == MON:
             return [
-                (date(year, 12, 27), "Christmas Eve shift"),
+                (date(year, 12, 27), "Christmas Eve Shift"),
             ]
 
     def get_variable_days(self, year):


### PR DESCRIPTION
This one's change a suggestion. It makes it easier to rename such holidays in your own code, e.g. by replacing " Shift" with " Substitute" or " (in lieau)". Unless there was some method to the madness (I mean, perhaps the inconsistencies were there for a reason..).

- [x] Tests with a significant number of years to be tested for your calendar.
- [ ] Changelog amended with a mention like: "Added ``<country>`` by ``@pseudo`` (#)". 

<!-- Release management

- Commit for the tag:
    - [ ] Edit version in setup.py
    - [ ] Add version in Changelog.md ; trim things
    - [ ] Push & wait for the tests to be green
    - [ ] tag me.
    - [ ] build sdist + wheel packages (``make package``)
- Back to dev commit:
    - [ ] Edit version in setup.py
    - [ ] Add the "master / nothing to see here" in Changelog.md
    - [ ] Push & wait for the tests to be green
- [ ] Merge --ff
- Github stuff
    - [ ] Push tag in Github
    - [ ] Edit release on Github using the changelog.
    - [ ] Delete branch
- [ ] upload release on PyPI using ``twine``
- [ ] (*optional*) Make feeback on the various PR or issues.

 -->
