### PR TITLE
The ``IsoRegistry.items()`` method has been removed from the API

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+* **BREAKING CHANGE**: the ``IsoRegistry.items()`` method has been removed from the API. You must use the ``get_calendars()`` to perform the same registry queries (#375, #491).
 
 ## v8.4.0 (2020-04-17)
 

--- a/docs/iso-registry.md
+++ b/docs/iso-registry.md
@@ -8,7 +8,7 @@ As of version 3.0 (August/September 2018), we have introduced a global calendar 
 
 ```python
 >>> from workalendar.registry import registry
->>> calendars = registry.get_calendars()
+>>> calendars = registry.get_calendars()  # This returns a dictionary
 >>> for code, calendar_class in calendars.items():
 ...     print("`{}` is code for '{}'".format(code, calendar_class.name))
 `AT` is code for 'Austria'
@@ -26,7 +26,7 @@ As of version 3.0 (August/September 2018), we have introduced a global calendar 
 
 The "private property" `registry.region_registry` is a `dict` object, with the ISO code as a key, and the calendar class as the value. As a "workalendar standard", **every** calendar in the registry has a `name` property (derived from the docstring), so you'd probably be able to build a user-friendly list of available calendars, for a dropdown list, for example.
 
-**DEPRECATION WARNING**: the ``get_calendars`` method used to be named ``items()``. In a future release, it'll be deprecated and re-purposed. Please switch to using ``get_calendars()`` for all your queries in the registry.
+**DEPRECATION WARNING**: As of version 9.0.0, the ``IsoRegistry.items()`` has been renamed into ``IsoRegistry.get_calendars()`` for all your queries in the registry.
 
 ## Retrieve a collection of regions
 

--- a/workalendar/registry.py
+++ b/workalendar/registry.py
@@ -1,5 +1,4 @@
 from importlib import import_module
-import warnings
 
 from .core import Calendar
 from .exceptions import ISORegistryError
@@ -90,24 +89,6 @@ class IsoRegistry:
             if key.startswith("{}-".format(iso_code)):
                 items[key] = value
         return items
-
-    def items(self, region_codes=None, include_subregions=False):
-        """
-        Returns calendar classes for regions
-
-        :param region_codes list of ISO codes for selected regions. If empty,
-                            the function will return all items from the
-                            registry.
-        :param include_subregions boolean if subregions
-        of selected regions should be included in result
-        :rtype dict
-        :return dict where keys are ISO codes strings
-        and values are calendar classes
-        """
-        warnings.warn("The ``items()`` method will soon be deprecated."
-                      " Please use ``get_calendars()`` instead.",
-                      DeprecationWarning)
-        return self.get_calendars(region_codes, include_subregions)
 
     def get_calendars(self, region_codes=None, include_subregions=False):
         """

--- a/workalendar/tests/test_registry.py
+++ b/workalendar/tests/test_registry.py
@@ -1,5 +1,4 @@
 from unittest import TestCase
-import warnings
 
 from ..core import Calendar
 from ..exceptions import ISORegistryError
@@ -47,19 +46,6 @@ class NonStandardRegistryTest(TestCase):
         self.assertEqual(calendar_class, SubRegionCalendar)
         # Unknown code/region
         self.assertIsNone(registry.get_calendar_class('XX'))
-
-    def test_items_deprecation(self):
-        registry = IsoRegistry(load_standard_modules=False)
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-            # Trigger a warning.
-            registry.items()
-            # Verify some things
-            self.assertEqual(len(w), 1)
-            warning = w[0]
-            self.assertTrue(issubclass(warning.category, DeprecationWarning))
-            self.assertIn("deprecated", str(warning.message))
 
     def test_get_subregions(self):
         registry = IsoRegistry(load_standard_modules=False)
@@ -144,7 +130,7 @@ class NonStandardRegistryTest(TestCase):
         self.assertEqual(set({"RE", "RE2", "RE3"}), set(calendars.keys()))
 
         # Should be equivalent to [] + include subregions
-        calendars = registry.items(include_subregions=True)
+        calendars = registry.get_calendars(include_subregions=True)
         self.assertEqual(len(calendars), 4)
         self.assertEqual(
             set({"RE", "RE2", "RE3", "RE-SR"}),


### PR DESCRIPTION
This is a **BREAKING CHANGE**.
You must use the ``get_calendars()`` to perform the same registry queries
refs #375, closes #491.


- [x] Tests with no regression.
- [x] Documentation is amended.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
