### PR TITLE
v9.0.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## master (unreleased)
+
+Nothing here yet.
+
 ## v9.0.0 (2020-04-24)
 
 - **BREAKING CHANGE**: the ``IsoRegistry.items()`` method has been removed from the API. You must use the ``get_calendars()`` to perform the same registry queries (#375, #491).

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## master (unreleased)
+## v9.0.0 (2020-04-24)
 
 - **BREAKING CHANGE**: the ``IsoRegistry.items()`` method has been removed from the API. You must use the ``get_calendars()`` to perform the same registry queries (#375, #491).
 - *Deprecation notice*: The usage of ``IsoRegistry.get_calendar_class()`` is strongly discouraged, in favor of ``get()``. The ``get_calendar_class`` method will be dropped in a further release. In the meantime, they'll be both equivalent (#375, #418).

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ REQUIREMENTS = [
     'pyluach',
     'setuptools>=1.0',
 ]
-version = '9.0.0'
+version = '9.1.0.dev0'
 __VERSION__ = version
 
 params = dict(

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ REQUIREMENTS = [
     'pyluach',
     'setuptools>=1.0',
 ]
-version = '8.5.0.dev0'
+version = '9.0.0'
 __VERSION__ = version
 
 params = dict(


### PR DESCRIPTION
**BREAKING CHANGES** in the Registry API.

* Dropped the ``IsoRegistry.items()`` method,
* Started deprecation of the ``IsoRegistry.get_calendar_class`` method.

refs #375 


- Commit for the tag:
    - [x] Edit version in setup.py
    - [x] Add version in Changelog.md ; trim things
    - [x] Push & wait for the tests to be green
    - [x] tag me.
    - [x] build sdist + wheel packages (``make package``)
- Back to dev commit:
    - [x] Edit version in setup.py
    - [x] Add the "master / nothing to see here" in Changelog.md
    - [x] Push & wait for the tests to be green
- [ ] Merge --ff
- Github stuff
    - [ ] Push tag in Github
    - [ ] Edit release on Github using the changelog.
    - [ ] Delete branch
- [ ] upload release on PyPI using ``twine``
- [ ] (*optional*) Make feeback on the various PR or issues.
