### PR TITLE
Removed the ``IsoRegistry.get_calendar_class()`` method

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- **BREAKING CHANGE**: the ``IsoRegistry.get_calendar_class()`` method has been removed from the code and should no longer be used (#375, #495).
 
 ## v9.2.0 (2020-06-02)
 

--- a/docs/iso-registry.md
+++ b/docs/iso-registry.md
@@ -129,6 +129,8 @@ Let's say that we only know the ISO code for Switzerland (`CH`). If we want to c
 
 *Note*: this function would return `None` if the code is unknown.
 
+**DEPRECATION WARNING**: As of version X.X.X, the ``IsoRegistry.get_calendar_class()`` has been renamed into ``IsoRegistry.get()`` to retrieve a single calendar class out of the registry.
+
 
 ## Select only sub-regions
 

--- a/workalendar/registry.py
+++ b/workalendar/registry.py
@@ -1,5 +1,4 @@
 from importlib import import_module
-import warnings
 
 from .core import Calendar
 from .exceptions import ISORegistryError
@@ -58,17 +57,6 @@ class IsoRegistry:
                 iso_code, class_name = iso_stuff
                 if iso_code and cls.__name__ == class_name:
                     self.register(iso_code, cls)
-
-    def get_calendar_class(self, iso_code):
-        """
-        Alias for the ``get(iso_code)`` method.
-
-        This alias will be deprecated in a further release.
-        """
-        warnings.warn("The ``get_calendar_class(iso_code)`` method will soon"
-                      " be deprecated. Please use ``get(iso_code)`` instead.",
-                      DeprecationWarning)
-        return self.get(iso_code)
 
     def get(self, iso_code):
         """

--- a/workalendar/tests/test_registry.py
+++ b/workalendar/tests/test_registry.py
@@ -1,5 +1,4 @@
 from unittest import TestCase
-import warnings
 
 from ..core import Calendar
 from ..exceptions import ISORegistryError
@@ -37,7 +36,6 @@ class NonStandardRegistryTest(TestCase):
             registry.register("NAC", NotACalendarClass)
 
     def test_get(self):
-        # get() is the new name for `get_calendar_class()`
         registry = IsoRegistry(load_standard_modules=False)
         registry.register('RE', self.region)
         registry.register('RE-SR', self.subregion)
@@ -48,27 +46,6 @@ class NonStandardRegistryTest(TestCase):
         self.assertEqual(calendar_class, SubRegionCalendar)
         # Unknown code/region
         self.assertIsNone(registry.get('XX'))
-
-    def test_get_calendar_class_alias(self):
-        registry = IsoRegistry(load_standard_modules=False)
-        registry.register('RE', self.region)
-        self.assertEqual(
-            registry.get('RE'),
-            registry.get_calendar_class('RE')
-        )
-
-    def test_get_calendar_class_deprecation(self):
-        registry = IsoRegistry(load_standard_modules=False)
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-            # Trigger a warning.
-            registry.get_calendar_class("RE")
-            # Verify some things
-            self.assertEqual(len(w), 1)
-            warning = w[0]
-            self.assertTrue(issubclass(warning.category, DeprecationWarning))
-            self.assertIn("deprecated", str(warning.message))
 
     def test_get_subregions(self):
         registry = IsoRegistry(load_standard_modules=False)


### PR DESCRIPTION
refs #375, #495


* [x] Drop from code,
* [x] Check for documentation uses (it should be fine, but you never know)
* [x] Amend documentation to mention the version it was dropped,
* [x] Remove related tests (alias + deprecation warning).