### PR TITLE
Brazil: Consciencia negra day is not a national holiday

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Bugfix: setting *Consciência Negra day* as a non-holiday by default for Brazilian calendars, thx to @edniemeyer (#516).
 
 ## v10.1.0 (2020-06-18)
 

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -25,7 +25,7 @@ class Brazil(WesternCalendar, ChristianMixin):
     include_servidor_publico = False
     servidor_publico_label = "Dia do Servidor Público"
     # Consciência Negra day
-    include_consciencia_negra = True
+    include_consciencia_negra = False
     # There are two dates for the Consciência Negra day
     # The most common is November, 20th
     consciencia_negra_day = (11, 20)

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -579,7 +579,6 @@ class BrazilBankCalendar(Brazil):
     include_good_friday = True
     include_ash_wednesday = True
     include_corpus_christi = True
-    include_consciencia_negra = False
     include_easter_sunday = False
 
     def get_last_day_of_year_for_only_internal_bank_trans(self, year):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -30,6 +30,7 @@ from ..america.brazil import IBGE_REGISTER, IBGE_TUPLE
 
 class BrazilTest(GenericCalendarTest):
     cal_class = Brazil
+    test_include_consciencia_negra = False
 
     def test_year_2013_federal(self):
         holidays = self.cal.holidays_set(2013)
@@ -41,6 +42,20 @@ class BrazilTest(GenericCalendarTest):
         self.assertIn(date(2013, 11, 2), holidays)  # Finados
         self.assertIn(date(2013, 11, 15), holidays)  # Proclamação da República
         self.assertIn(date(2013, 12, 25), holidays)  # Natal
+
+    def test_consciencia_negra(self):
+        # Consciência Negra day is not a national holiday
+        # It's triggered in the appropriate classes, so this test needs to
+        # be overwritten.
+        month, day = self.cal.consciencia_negra_day
+        consciencia_negra_day = date(self.year, month, day)
+        holidays = self.cal.holidays_set(self.year)
+        if self.test_include_consciencia_negra:
+            # Included where needed
+            self.assertIn(consciencia_negra_day, holidays)
+        else:
+            # By default, not in the holidays.
+            self.assertNotIn(consciencia_negra_day, holidays)
 
 
 class BrazilAcreTest(BrazilTest):
@@ -59,6 +74,7 @@ class BrazilAcreTest(BrazilTest):
 
 class BrazilAlagoasTest(BrazilTest):
     cal_class = BrazilAlagoas
+    test_include_consciencia_negra = True
 
     def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
@@ -71,6 +87,7 @@ class BrazilAlagoasTest(BrazilTest):
 
 class BrazilAmapaTest(BrazilTest):
     cal_class = BrazilAmapa
+    test_include_consciencia_negra = True
 
     def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
@@ -89,6 +106,7 @@ class BrazilAmapaTest(BrazilTest):
 
 class BrazilAmazonasTest(BrazilTest):
     cal_class = BrazilAmazonas
+    test_include_consciencia_negra = True
 
     def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
@@ -164,6 +182,7 @@ class BrazilMinasGeraisTest(BrazilTest):
 
 class BrazilMatoGrossoTest(BrazilTest):
     cal_class = BrazilMatoGrosso
+    test_include_consciencia_negra = True
 
     def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
@@ -226,6 +245,7 @@ class BrazilParanaTest(BrazilTest):
 
 class BrazilRioDeJaneiroTest(BrazilTest):
     cal_class = BrazilRioDeJaneiro
+    test_include_consciencia_negra = True
 
     def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
@@ -318,6 +338,7 @@ class SaoPauloStateTest(BrazilTest):
 
 class SaoPauloCityTest(SaoPauloStateTest):
     cal_class = BrazilSaoPauloCity
+    test_include_consciencia_negra = True
 
     def test_year_2013_city(self):
         holidays = self.cal.holidays_set(2013)
@@ -449,6 +470,7 @@ class BrazilGuarapariCityTest(BrazilEspiritoSantoTest):
     Guarapari city is in the Espírito Santo state
     """
     cal_class = BrazilGuarapariCity
+    test_include_consciencia_negra = True
 
     def test_year_2017_city(self):
         holidays = self.cal.holidays_set(2017)


### PR DESCRIPTION
taking over the branch initiated by @Edniemeyer

superseeds and thus, would close #516 

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. 
