### PR TITLE
new feature: method to export any Calendar to .ical

### DIFF
--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -828,30 +828,30 @@ class CoreCalendar:
             holidays += self.holidays(year)
 
         # initialize icalendar
-        mycal = icalendar.Calendar()
-        mycal.add('prodid', '-//workalendar//ical %s//EN' % __version__)
-        mycal.add('version', '2.0')  # current RFC5545 version
-        now = datetime.now()
+        ics = ('BEGIN:VCALENDAR\n'
+               'VERSION:2.0\n'  # current RFC5545 version
+               'PRODID:-//workalendar//ical 9.0.0//EN\n')
+        common_timestamp = datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
+        dtstamp = 'DTSTAMP;VALUE=DATE-TIME:%s\n' % common_timestamp
 
         # add an event for each holiday
         for date_, name in holidays:
-            event = icalendar.Event()
-            uid = '%s%s@peopledoc.github.io/workalendar' % (date_, name)
-            event.add('uid', uid)
-            event.add('dtstamp', now)
-            event.add('dtstart', date_)
-            event.add('summary', name)
-            mycal.add_component(event)
+            ics += 'BEGIN:VEVENT\n'
+            ics += 'SUMMARY:%s\n' % name
+            ics += 'DTSTART;VALUE=DATE:%s\n' % date_.strftime('%Y%m%d')
+            ics += dtstamp
+            ics += 'UID:%s%s@peopledoc.github.io/workalendar\n' % (date_, name)
+            ics += 'END:VEVENT\n'
 
-        # convert to ical
-        ical = mycal.to_ical()
+        # add footer
+        ics += 'END:VCALENDAR\n'
 
         # save iCal file
         ical_extensions = ['.ical', '.ics', '.ifb', '.icalendar']
-        if os.path.splitext(target_path) not in ical_extensions:
+        if os.path.splitext(target_path)[1] not in ical_extensions:
             target_path += '.ics'
-        with open(target_path, 'wb') as export_file:
-            export_file.write(ical)
+        with open(target_path, 'w+') as export_file:
+            export_file.write(ics)
 
 class Calendar(CoreCalendar):
     """

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -851,6 +851,7 @@ class CoreCalendar:
         with open(target_path, 'w+') as export_file:
             export_file.write(ics)
 
+
 class Calendar(CoreCalendar):
     """
     The cornerstone of Earth calendars.

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -10,10 +10,8 @@ from datetime import date, timedelta, datetime
 from calverter import Calverter
 from dateutil import easter
 from lunardate import LunarDate
-import icalendar
 
 from .exceptions import UnsupportedDateType, CalendarError
-from .__init__ import __version__
 
 MON, TUE, WED, THU, FRI, SAT, SUN = range(7)
 

--- a/workalendar/tests/__init__.py
+++ b/workalendar/tests/__init__.py
@@ -1,6 +1,8 @@
+import os
+import os.path
 import warnings
 from datetime import date
-from unittest import TestCase
+from unittest import TestCase, skipIf
 
 from ..core import Calendar
 
@@ -13,3 +15,49 @@ class GenericCalendarTest(TestCase):
         warnings.simplefilter('ignore')
         self.year = date.today().year
         self.cal = self.cal_class()
+
+    # test for ical export that runs on every calendar
+    @skipIf(cal_class == Calendar, reason='Calendar has no holidays.')
+    def test_ical_export(self):
+        """Check that an iCal file can be created according to iCal spec."""
+        holidays = self.cal.holidays(2020) + self.cal.holidays(2021)
+        test_file_name = '%s_failed_test' % self.cal_class.name
+        test_file_name = os.path.join(
+            os.path.dirname(__file__), 'failed_ical_exports', test_file_name)
+        self.cal.export_to_ical(target_path=test_file_name,
+                                period=[2020, 2021])
+        with open(test_file_name) as ics_file:
+            # check header
+            assert ics_file.readline() == 'BEGIN:VCALENDAR\n'
+            assert ics_file.readline() == 'VERSION:2.0\n'
+            assert ics_file.readline().startswith(
+                'PRODID:-//workalendar//ical ')
+            # check new year
+            assert ics_file.readline() == 'BEGIN:VEVENT\n'
+            if not self.cal.shift_new_years_day:
+                assert ics_file.readline() == 'SUMMARY:New year\n'
+                assert ics_file.readline() == 'DTSTART;VALUE=DATE:20200101\n'
+                assert ics_file.readline().startswith(
+                    'DTSTAMP;VALUE=DATE-TIME:')
+                first_uid_line = ics_file.readline()
+                uid_lines = [first_uid_line]
+                assert first_uid_line.startswith('UID:')
+                assert ics_file.readline() == 'END:VEVENT\n'
+            else:
+                uid_lines = []
+            remaining_lines = ics_file.readlines()
+            uid_lines += [line for line in remaining_lines
+                         if line.startswith('UID:')]
+            # check number of entries
+            assert len(uid_lines) == len(holidays)
+            # check that UIDs are unique within the calendar
+            assert len(uid_lines) == len(set(uid_lines))
+            # check that final year is included
+            assert remaining_lines[-3].startswith('UID:2021')
+            # check last few lines of file
+            assert remaining_lines[-2] == 'END:VEVENT\n'
+            assert remaining_lines[-1] == 'END:VCALENDAR\n'
+        # A standard iCal extension should have been added automatically:
+        test_file_name += '.ics'
+        # Remove the .ics file if this test passes
+        os.remove(test_file_name)

--- a/workalendar/tests/__init__.py
+++ b/workalendar/tests/__init__.py
@@ -15,6 +15,7 @@ class CoreCalendarTest(TestCase):
         self.year = date.today().year
         self.cal = self.cal_class()
 
+
 class GenericCalendarTest(CoreCalendarTest):
     test_include_january_1st = True
 
@@ -77,7 +78,7 @@ class GenericCalendarTest(CoreCalendarTest):
                 uid_lines = []
             remaining_lines = ics_file.readlines()
             uid_lines += [line for line in remaining_lines
-                         if line.startswith('UID:')]
+                          if line.startswith('UID:')]
             # check number of entries
             assert len(uid_lines) == len(holidays)
             # check that UIDs are unique within the calendar

--- a/workalendar/tests/failed_ical_exports/folder_readme.md
+++ b/workalendar/tests/failed_ical_exports/folder_readme.md
@@ -1,0 +1,3 @@
+If the test `test_ical_export` in `workalendar/tests/__init__.py` fails, the wrongly exported iCalendar file is kept in this folder.
+
+On the master branch, this folder should be kept empty.

--- a/workalendar/usa/core.py
+++ b/workalendar/usa/core.py
@@ -191,16 +191,21 @@ class UnitedStates(WesternCalendar):
         day = UnitedStates.get_nth_weekday_in_month(year, 2, MON, 3)
         return (day, self.presidents_day_label)
 
-    def get_cesar_chavez_days(self, year):
+    def get_cesar_chavez_day(self, year):
         """
-        Cesar Chavez day is on 31st of March, float to 1st April if Monday.
+        Cesar Chavez Day is on the 31st of March.
 
-        Will return a list of days.
+        Schools and State offices closed in:
+        * Arizona,
+        * California,
+        * Colorado,
+        * Michigan,
+        * New Mexico,
+        * Texas,
+        * Utah,
+        * Wisconsin
         """
-        days = [(date(year, 3, 31), "Cesar Chavez Day")]
-        if date(year, 3, 31).weekday() == SUN:
-            days.append((date(year, 4, 1), "Cesar Chavez Day (Observed)"))
-        return days
+        return (date(year, 3, 31), "Cesar Chavez Day")
 
     def get_patriots_day(self, year):
         """3rd Monday of April"""
@@ -296,7 +301,7 @@ class UnitedStates(WesternCalendar):
             days.append(self.get_lincoln_birthday(year))
 
         if self.include_cesar_chavez_day:
-            days.extend(self.get_cesar_chavez_days(year))
+            days.append(self.get_cesar_chavez_day(year))
 
         if self.include_patriots_day:
             days.append(self.get_patriots_day(year))


### PR DESCRIPTION
Introducing a a feature originally discussed in #197

### Feature Description

This adds a method to the calendar class which allows users to export the calendar to the standard `.ical` format.

Usage:
```
>>> cal = Austria()
>>> cal.export_to_ical('austrian_calendar')  # -> austrian_calendar.ics
```
iCalendar is the standard for calendar sharing and hence `.ics` files can be imported into almost all Calendar apps on desktop computers, smartphones, and even dumbphones. For details see: [https://icalendar.org/](https://icalendar.org/)

### Release management

- Commit for the tag:
    - [ ] Edit version in setup.py
    - [ ] Add version in Changelog.md ; trim things
    - [ ] Push & wait for the tests to be green
    - [ ] tag me.
    - [ ] build sdist + wheel packages (``make package``)
- Back to dev commit:
    - [ ] Edit version in setup.py
    - [ ] Add the "master / nothing to see here" in Changelog.md
    - [ ] Push & wait for the tests to be green
- [ ] Merge --ff
- Github stuff
    - [ ] Push tag in Github
    - [ ] Edit release on Github using the changelog.
    - [ ] Delete branch
- [ ] upload release on PyPI using ``twine``
- [ ] (*optional*) Make feeback on the various PR or issues.
