### PR TITLE
Migrating Labour Day as a worldwide holiday

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,8 @@
 
 ## master (unreleased)
 
-- Small refactoring for the Colombia / added docstrings & comments to explain why we're not using stock options. Added tests for year 2020 and handling shift exceptions. (#509).
+- Small refactoring for the Colombia / added docstrings & comments to explain why we're not using stock options. Added tests for year 2020 and handling shift exceptions (#509).
+- Migrating Labour Day as a worldwide holiday, disabled by default, but activated (to date) for about 50 countries (including label change when necessary), `contributing.md` documentation amended (#467).
 
 ## v10.3.0 (2020-07-10)
 

--- a/contributing.md
+++ b/contributing.md
@@ -123,13 +123,17 @@ With the `WesternCalendar` base class you have at least one holiday as a bonus: 
 
 ```python
 class Zhraa(WesternCalendar):
+
+    include_labour_day = True
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (8, 2, "King Birthday"),
     )
 ```
 
+The `include_labour_day` is a flag common to all subclasses of `workalendar.core.Calendar`. Setting it to `True` activates the Labour Day for this calendar. Please note that there's a way to overwrite its label, using the `labour_day_label` class property.
+
 Now we've got 3 holidays out of 6.
+
 
 #### Add religious holidays
 
@@ -140,8 +144,8 @@ from ..core import WesternCalendar
 
 class Zhraa(WesternCalendar):
     include_easter_monday = True
+    include_labour_day = True
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (8, 2, "King Birthday"),
     )
 ```
@@ -154,8 +158,8 @@ There are many static methods that will grant you a clean access to variable day
 ```python
 class Zhraa(WesternCalendar):
     include_easter_monday = True
+    include_labour_day = True
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (8, 2, "King Birthday"),
     )
 

--- a/workalendar/africa/algeria.py
+++ b/workalendar/africa/algeria.py
@@ -5,6 +5,8 @@ from ..registry_tools import iso_register
 @iso_register('DZ')
 class Algeria(IslamicCalendar):
     "Algeria"
+    # Civil holidays
+    include_labour_day = True
     # Islamic holidays
     include_prophet_birthday = True
     include_eid_al_fitr = True
@@ -12,7 +14,6 @@ class Algeria(IslamicCalendar):
     include_islamic_new_year = True
 
     FIXED_HOLIDAYS = IslamicCalendar.FIXED_HOLIDAYS + (
-            (5, 1, "Labour Day"),
             (7, 5, "Independence Day"),
             (11, 1, "Anniversary of the revolution"),
         )

--- a/workalendar/africa/angola.py
+++ b/workalendar/africa/angola.py
@@ -5,6 +5,10 @@ from ..registry_tools import iso_register
 @iso_register('AO')
 class Angola(WesternCalendar):
     "Angola"
+    # Civil holiday
+    include_labour_day = True
+    labour_day_label = "Dia Internacional do Trabalhador"
+    # Christian holidays
     include_fat_tuesday = True
     fat_tuesday_label = "Dia de Carnaval"
     include_good_friday = True
@@ -16,7 +20,6 @@ class Angola(WesternCalendar):
         (2, 4, "Dia do Inicio da Luta Armada"),
         (3, 8, "Dia Internacional da Mulher"),
         (4, 4, "Dia da Paz"),
-        (5, 1, "Dia Internacional do Trabalhador"),
         (9, 17, "Dia do Fundador da Nação e do Herói Nacional"),
         (11, 11, "Dia da Independência Nacional"),
     )

--- a/workalendar/africa/benin.py
+++ b/workalendar/africa/benin.py
@@ -5,6 +5,8 @@ from ..registry_tools import iso_register
 @iso_register('BJ')
 class Benin(IslamoWesternCalendar):
     "Benin"
+    # Civil holidays
+    include_labour_day = True
     # Christian holidays
     include_easter_monday = True
     include_ascension = True
@@ -19,7 +21,6 @@ class Benin(IslamoWesternCalendar):
 
     FIXED_HOLIDAYS = IslamoWesternCalendar.FIXED_HOLIDAYS + (
         (1, 10, "Traditional Day"),
-        (5, 1, "Labour Day"),
         (8, 1, "Independence Day"),
         (10, 26, "Armed Forces Day"),
         (11, 30, "National Day"),

--- a/workalendar/africa/ivory_coast.py
+++ b/workalendar/africa/ivory_coast.py
@@ -5,6 +5,8 @@ from ..registry_tools import iso_register
 @iso_register('CI')
 class IvoryCoast(IslamoWesternCalendar):
     "Ivory Coast"
+    # Civil holidays
+    include_labour_day = True
     # Christian holidays
     include_easter_monday = True
     include_ascension = True
@@ -18,7 +20,6 @@ class IvoryCoast(IslamoWesternCalendar):
     include_day_of_sacrifice_label = "Feast of the Sacrifice"
 
     FIXED_HOLIDAYS = IslamoWesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (8, 7, "Independence Day"),
         (11, 15, "National Peace Day"),
     )

--- a/workalendar/africa/kenya.py
+++ b/workalendar/africa/kenya.py
@@ -8,6 +8,8 @@ from ..registry_tools import iso_register
 @iso_register('KE')
 class Kenya(IslamoWesternCalendar):
     "Kenya"
+    # Civil holidays
+    include_labour_day = True
     # Christian holidays
     include_good_friday = True
     include_easter_monday = True
@@ -20,7 +22,6 @@ class Kenya(IslamoWesternCalendar):
     WEEKEND_DAYS = (SAT, SUN)
 
     FIXED_HOLIDAYS = IslamoWesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (6, 1, "Madaraka Day"),
         (10, 20, "Mashujaa Day"),
         (12, 12, "Jamhuri Day"),

--- a/workalendar/africa/madagascar.py
+++ b/workalendar/africa/madagascar.py
@@ -7,9 +7,11 @@ class Madagascar(WesternCalendar):
     "Madagascar"
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (3, 29, "Martyrs' Day"),
-        (5, 1, "Labour Day"),
         (6, 26, "Independence Day"),
     )
+    # Civil holidays
+    include_labour_day = True
+    # Christian holidays
     include_easter_monday = True
     include_ascension = True
     include_whit_monday = True

--- a/workalendar/africa/sao_tome.py
+++ b/workalendar/africa/sao_tome.py
@@ -7,10 +7,12 @@ class SaoTomeAndPrincipe(WesternCalendar):
     "São Tomé and Príncipe"
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (2, 3, "Martyr's Day"),
-        (5, 1, "Labour Day"),
         (7, 12, "Independence Day"),
         (9, 6, "Armed Forces Day"),
         (9, 30, "Agricultural Reform Day"),
         (12, 21, "São Tomé Day"),
     )
+    # Civil holidays
+    include_labour_day = True
+    # Christian holidays
     include_all_saints = True

--- a/workalendar/america/argentina.py
+++ b/workalendar/america/argentina.py
@@ -6,7 +6,10 @@ from ..registry_tools import iso_register
 @iso_register('AR')
 class Argentina(WesternCalendar):
     'Argentina'
-
+    # Civil holidays
+    include_labour_day = True
+    labour_day_label = "Día del Trabajador"
+    # Christian holidays
     include_fat_tuesday = True
     fat_tuesday_label = "Carnival"
     include_good_friday = True
@@ -16,7 +19,6 @@ class Argentina(WesternCalendar):
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (3, 24, "Día Nacional de la Memoria por la Verdad y la Justicia"),
-        (5, 1, "Día del Trabajador"),
         (5, 25, "Día de la Revolución de Mayo"),
         (6, 20, "Día Paso a la Inmortalidad del General Manuel Belgrano"),
         (7, 9, "Día de la Independencia"),

--- a/workalendar/america/barbados.py
+++ b/workalendar/america/barbados.py
@@ -8,7 +8,9 @@ from ..registry_tools import iso_register
 @iso_register("BB")
 class Barbados(WesternCalendar):
     "Barbados"
-
+    # Civil holidays
+    include_labour_day = True
+    # Christian holidays
     include_good_friday = True
     include_easter_sunday = True
     include_easter_monday = True
@@ -19,7 +21,6 @@ class Barbados(WesternCalendar):
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (1, 21, "Errol Barrow Day"),
         (4, 28, "National Heroes Day"),
-        (5, 1, "Labour Day"),
         (8, 1, "Emancipation Day"),
         (11, 30, "Independance Day"),
     )

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -9,7 +9,6 @@ class Brazil(WesternCalendar):
     "Brazil"
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (4, 21, "Tiradentes' Day"),
-        (5, 1, "Labour Day"),
         (9, 7, "Independence Day"),
         (10, 12, "Our Lady of Aparecida"),
         (11, 2, "All Souls' Day"),
@@ -21,6 +20,8 @@ class Brazil(WesternCalendar):
     sao_pedro_label = "São Pedro"
     include_sao_joao = False
     sao_joao_label = "São João"
+    # Civil holidays
+    include_labour_day = True
     include_servidor_publico = False
     servidor_publico_label = "Dia do Servidor Público"
     # Consciência Negra day
@@ -30,6 +31,7 @@ class Brazil(WesternCalendar):
     consciencia_negra_day = (11, 20)
     consciencia_negra_label = "Consciência Negra"
     include_nossa_senhora_conceicao = False
+    # Christian holidays
     include_easter_sunday = True
 
     def get_variable_days(self, year):

--- a/workalendar/america/chile.py
+++ b/workalendar/america/chile.py
@@ -8,7 +8,6 @@ from ..registry_tools import iso_register
 class Chile(WesternCalendar):
     "Chile"
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (5, 21, "Navy Day"),
         (6, 29, "Saint Peter and Saint Paul"),
         (7, 16, "Our Lady of Mount Carmel"),
@@ -17,6 +16,9 @@ class Chile(WesternCalendar):
         (10, 12, "Columbus Day"),
         (12, 31, "Banking Holiday"),
     )
+    # Civil holidays
+    include_labour_day = True
+    # Christian holidays
     include_good_friday = True
     include_easter_saturday = True
     include_assumption = True

--- a/workalendar/america/colombia.py
+++ b/workalendar/america/colombia.py
@@ -8,10 +8,12 @@ from ..registry_tools import iso_register
 class Colombia(WesternCalendar):
     "Colombia"
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (7, 20, "Independence Day"),
         (8, 7, "Boyacá Battle"),
     )
+    # Civil holidays
+    include_labour_day = True
+    # Christian holidays
     include_palm_sunday = True
     include_holy_thursday = True
     include_good_friday = True

--- a/workalendar/america/mexico.py
+++ b/workalendar/america/mexico.py
@@ -8,9 +8,10 @@ from ..registry_tools import iso_register
 class Mexico(WesternCalendar):
     "Mexico"
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (9, 16, "Independence Day"),
     )
+    # Civil holidays
+    include_labour_day = True
 
     def get_variable_days(self, year):
         days = super().get_variable_days(year)

--- a/workalendar/america/panama.py
+++ b/workalendar/america/panama.py
@@ -7,13 +7,15 @@ from ..registry_tools import iso_register
 @iso_register('PA')
 class Panama(WesternCalendar):
     "Panama"
+    # Civil holidays
+    include_labour_day = True
+    # Christian holidays
     include_good_friday = True
     include_easter_saturday = True
     include_easter_sunday = True
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (1, 9, "Martyrs' Day"),
-        (5, 1, "Labour Day"),
         (11, 3, "Independence Day"),
         (11, 5, "Colon Day"),
         (11, 10, "Shout in Villa de los Santos"),

--- a/workalendar/america/paraguay.py
+++ b/workalendar/america/paraguay.py
@@ -8,12 +8,14 @@ from ..registry_tools import iso_register
 class Paraguay(WesternCalendar):
     "Paraguay"
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (5, 14, "Independence Day"),
         (6, 12, "Chaco Armistice"),
         (9, 19, "Army holiday"),
         (12, 8, "Virgin of Caacupé Day"),
     )
+    # Civil holidays
+    include_labour_day = True
+    # Christian holidays
     include_holy_thursday = True
     include_good_friday = True
     include_easter_saturday = True

--- a/workalendar/asia/hong_kong.py
+++ b/workalendar/asia/hong_kong.py
@@ -11,6 +11,9 @@ from ..registry_tools import iso_register
 @iso_register('HK')
 class HongKong(WesternMixin, ChineseNewYearCalendar):
     "Hong Kong"
+    # Civil holidays
+    include_labour_day = True
+    # Christian holidays
     include_good_friday = True
     include_easter_saturday = True
     include_easter_monday = True
@@ -19,7 +22,6 @@ class HongKong(WesternMixin, ChineseNewYearCalendar):
     WEEKEND_DAYS = (SUN,)
 
     FIXED_HOLIDAYS = ChineseNewYearCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (7, 1, "SAR Establishment Day"),
         (10, 1, "National Day"),
     )

--- a/workalendar/asia/malaysia.py
+++ b/workalendar/asia/malaysia.py
@@ -10,6 +10,11 @@ from ..registry_tools import iso_register
 @iso_register('MY')
 class Malaysia(IslamicMixin, ChineseNewYearCalendar):
     "Malaysia"
+    # Civil holidays
+    include_labour_day = True
+    labour_day_label = "Workers' Day"
+
+    # Islamic holidays
     include_nuzul_al_quran = True
     include_eid_al_fitr = True
     length_eid_al_fitr = 2
@@ -25,7 +30,6 @@ class Malaysia(IslamicMixin, ChineseNewYearCalendar):
 
     FIXED_HOLIDAYS = ChineseNewYearCalendar.FIXED_HOLIDAYS + (
         (2, 1, "Federal Territory Day"),
-        (5, 1, "Workers' Day"),
         (8, 31, "National Day"),
         (9, 16, "Malaysia Day"),
         (12, 25, "Christmas Day"),

--- a/workalendar/asia/singapore.py
+++ b/workalendar/asia/singapore.py
@@ -10,6 +10,9 @@ from ..registry_tools import iso_register
 @iso_register('SG')
 class Singapore(WesternMixin, IslamicMixin, ChineseNewYearCalendar):
     "Singapore"
+    # Civil holidays
+    include_labour_day = True
+
     # Christian holiday
     include_good_friday = True
 
@@ -20,7 +23,6 @@ class Singapore(WesternMixin, IslamicMixin, ChineseNewYearCalendar):
     day_of_sacrifice_label = "Hari Raya Haji"
 
     FIXED_HOLIDAYS = ChineseNewYearCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (8, 9, "National Day"),
     )
 
@@ -50,8 +52,8 @@ class Singapore(WesternMixin, IslamicMixin, ChineseNewYearCalendar):
         2017: date(2017, 10, 18),
         2018: date(2018, 11, 6),
         2019: date(2019, 10, 27),
-        2020: date(2020, 11, 14),   # This might change
-        2021: date(2021, 11, 4),
+        2020: date(2020, 11, 14),
+        2021: date(2021, 11, 4),  # This might change
     }
     chinese_new_year_label = "Chinese Lunar New Year's Day"
     include_chinese_second_day = True

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -802,12 +802,19 @@ class Calendar(CoreCalendar):
     """
     include_new_years_day = True
     shift_new_years_day = False
+    include_labour_day = False
+    labour_day_label = "Labour Day"
 
     def get_fixed_holidays(self, year):
         days = super().get_fixed_holidays(year)
         if self.include_new_years_day:
             days.insert(
                 0, (date(year, 1, 1), "New year")
+            )
+
+        if self.include_labour_day:
+            days.append(
+                (date(year, 5, 1), self.labour_day_label)
             )
         return days
 

--- a/workalendar/europe/austria.py
+++ b/workalendar/europe/austria.py
@@ -7,10 +7,12 @@ class Austria(WesternCalendar):
     'Austria'
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "National Holiday"),  # Staatsfeiertag
         (10, 26, "National Holiday"),  # Nationalfeiertag
     )
-
+    # Civil holidays
+    include_labour_day = True
+    labour_day_label = "State Holiday"  # Staatsfeiertag
+    # Christian holidays
     include_epiphany = True
     include_easter_monday = True
     include_ascension = True

--- a/workalendar/europe/belarus.py
+++ b/workalendar/europe/belarus.py
@@ -7,14 +7,16 @@ from ..registry_tools import iso_register
 class Belarus(OrthodoxCalendar):
     'Belarus'
     "as of http://president.gov.by/en/holidays_en/"
+    # Civil holidays
+    include_labour_day = True
 
+    # Christian holidays
     include_christmas = False
 
     FIXED_HOLIDAYS = OrthodoxCalendar.FIXED_HOLIDAYS + (
         (1, 2, "Day After New Year"),
         (1, 7, "Christmas (Orthodox)"),
         (3, 8, "International Women's Day"),
-        (5, 1, "Labour Day"),
         (5, 9, "Victory Day"),
         (7, 3, "Republic Day"),
         (11, 7, "October Revolution Day"),

--- a/workalendar/europe/belgium.py
+++ b/workalendar/europe/belgium.py
@@ -7,11 +7,13 @@ class Belgium(WesternCalendar):
     'Belgium'
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (7, 21, "National Day"),
         (11, 11, "Armistice of 1918"),
     )
+    # Civil holidays
+    include_labour_day = True
 
+    # Christian holidays
     include_easter_monday = True
     include_ascension = True
     include_whit_monday = True

--- a/workalendar/europe/bulgaria.py
+++ b/workalendar/europe/bulgaria.py
@@ -8,16 +8,20 @@ class Bulgaria(WesternCalendar):
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (3, 3, "Liberation Day"),  # Ден на Освобождението на Б
-        (5, 1, "International Workers' Day"),  # Ден на труда и на междунар
         (5, 6, "Saint George's Day"),  # Гергьовден, ден на храброс
         (5, 24, "Saints Cyril & Methodius Day"),  # Ден на българската просвет
         (9, 6, "Unification Day"),  # Ден на Съединението
         (9, 22, "Independence Day"),  # Ден на независимостта на Б
         # wikipedia says Non-attendance day for schools, otherwise a working da
         # (11, 1, "National Awakening Day"),  # Ден на народните будители
-
     )
 
+    # Civil holidays
+    include_labour_day = True
+    # Ден на труда и на междунар
+    labour_day_label = "International Workers' Day"
+
+    # Christian holidays
     include_easter_sunday = True
     include_easter_monday = True
     include_christmas_eve = True  # Бъдни вечер

--- a/workalendar/europe/croatia.py
+++ b/workalendar/europe/croatia.py
@@ -9,11 +9,15 @@ class Croatia(WesternCalendar):
     'Croatia'
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "International Workers' Day"),
         (6, 22, "Anti-Fascist Struggle Day"),
         (8, 5, "Victory & Homeland Thanksgiving & Day of Croatian defenders"),
     )
 
+    # Civil holidays
+    include_labour_day = True
+    labour_day_label = "International Workers' Day"
+
+    # Christian holidays
     include_epiphany = True
     include_easter_sunday = True
     include_easter_monday = True

--- a/workalendar/europe/cyprus.py
+++ b/workalendar/europe/cyprus.py
@@ -7,6 +7,10 @@ from ..registry_tools import iso_register
 class Cyprus(WesternCalendar):
     'Cyprus'
 
+    # Civil holidays
+    include_labour_day = True
+
+    # Christian holidays
     include_epiphany = True
     include_clean_monday = True
     include_good_friday = True
@@ -22,7 +26,6 @@ class Cyprus(WesternCalendar):
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (3, 25, "Greek Independence Day"),
         (4, 1, "Cyprus National Day"),
-        (5, 1, "Labour Day"),
         (7, 15, "Dormition of the Theotokos"),
         (10, 1, "Cyprus Independence Day"),
         (10, 28, "Greek National Day"),

--- a/workalendar/europe/czech_republic.py
+++ b/workalendar/europe/czech_republic.py
@@ -6,12 +6,15 @@ from ..registry_tools import iso_register
 class CzechRepublic(WesternCalendar):
     'Czech Republic'
 
+    # Civil holidays
+    include_labour_day = True
+
+    # Christian holidays
     include_easter_monday = True
     include_good_friday = True
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (1, 1, "Restoration Day of the Independent Czech State"),
-        (5, 1, "Labour Day"),
         (5, 8, "Liberation Day"),
         (7, 5, "Saints Cyril and Methodius Day"),
         (7, 6, "Jan Hus Day"),

--- a/workalendar/europe/european_central_bank.py
+++ b/workalendar/europe/european_central_bank.py
@@ -3,10 +3,12 @@ from ..core import WesternCalendar
 
 class EuropeanCentralBank(WesternCalendar):
     "European Central Bank"
+    # Civil holidays
+    include_labour_day = True
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (12, 26, "St. Stephen's Day"),
     )
 
+    # Christian holidays
     include_good_friday = True
     include_easter_monday = True

--- a/workalendar/europe/finland.py
+++ b/workalendar/europe/finland.py
@@ -7,6 +7,7 @@ from ..registry_tools import iso_register
 class Finland(WesternCalendar):
     'Finland'
 
+    # Christian holidays
     include_epiphany = True
     include_good_friday = True
     include_easter_sunday = True
@@ -18,8 +19,9 @@ class Finland(WesternCalendar):
     include_boxing_day = True
     boxing_day_label = "St. Stephen's Day"
 
+    # Civil holidays
+    include_labour_day = True
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (12, 6, "Independence Day"),
     )
 

--- a/workalendar/europe/france.py
+++ b/workalendar/europe/france.py
@@ -6,14 +6,16 @@ from ..registry_tools import iso_register
 class France(WesternCalendar):
     'France'
 
+    # Christian holidays
     include_easter_monday = True
     include_ascension = True
     include_whit_monday = True
     include_all_saints = True
     include_assumption = True
 
+    # Civil holidays
+    include_labour_day = True
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (5, 8, "Victory in Europe Day"),
         (7, 14, "Bastille Day"),
         (11, 11, "Armistice Day"),

--- a/workalendar/europe/germany.py
+++ b/workalendar/europe/germany.py
@@ -7,11 +7,13 @@ from ..registry_tools import iso_register
 class Germany(WesternCalendar):
     'Germany'
 
+    # Civil holidays
+    include_labour_day = True
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (10, 3, "Day of German Unity"),
     )
 
+    # Christian holidays
     include_easter_monday = True
     include_ascension = True
     include_whit_monday = True

--- a/workalendar/europe/greece.py
+++ b/workalendar/europe/greece.py
@@ -6,11 +6,14 @@ from ..registry_tools import iso_register
 class Greece(OrthodoxCalendar):
     'Greece'
 
+    # Civil holidays
+    include_labour_day = True
     FIXED_HOLIDAYS = OrthodoxCalendar.FIXED_HOLIDAYS + (
         (3, 25, "Independence Day"),
-        (5, 1, "Labour Day"),
         (10, 28, "Ohi Day"),
     )
+
+    # Christian holidays
     include_epiphany = True
     include_clean_monday = True
     include_annunciation = True

--- a/workalendar/europe/hungary.py
+++ b/workalendar/europe/hungary.py
@@ -6,6 +6,7 @@ from ..registry_tools import iso_register
 class Hungary(WesternCalendar):
     'Hungary'
 
+    # Christian holidays
     include_easter_sunday = True
     include_easter_monday = True
     include_whit_sunday = True
@@ -16,9 +17,10 @@ class Hungary(WesternCalendar):
     boxing_day_label = "Second Day of Christmas"
     include_all_saints = True
 
+    # Civil holidays
+    include_labour_day = True
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (3, 15, "National Day"),
-        (5, 1, "Labour Day"),
         (8, 20, "St Stephen's Day"),
         (10, 23, "National Day"),
     )

--- a/workalendar/europe/iceland.py
+++ b/workalendar/europe/iceland.py
@@ -7,6 +7,7 @@ from ..registry_tools import iso_register
 class Iceland(WesternCalendar):
     'Iceland'
 
+    # Christian holidays
     include_holy_thursday = True
     include_good_friday = True
     include_easter_monday = True
@@ -16,8 +17,9 @@ class Iceland(WesternCalendar):
     include_boxing_day = True
     boxing_day_label = "St Stephen's Day"
 
+    # Civil holidays
+    include_labour_day = True
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (6, 17, "Icelandic National Day"),
         (12, 31, "New Year's Eve"),
     )

--- a/workalendar/europe/italy.py
+++ b/workalendar/europe/italy.py
@@ -6,11 +6,15 @@ from ..registry_tools import iso_register
 class Italy(WesternCalendar):
     'Italy'
 
+    # Civil holidays
+    include_labour_day = True
+    labour_day_label = "International Workers' Day"
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (4, 25, "Liberation Day"),
-        (5, 1, "International Workers' Day"),
         (6, 2, "Republic Day"),
     )
+
+    # Christian holidays
     include_immaculate_conception = True
     include_epiphany = True
     include_easter_monday = True

--- a/workalendar/europe/latvia.py
+++ b/workalendar/europe/latvia.py
@@ -7,14 +7,16 @@ from ..registry_tools import iso_register
 class Latvia(WesternCalendar):
     'Latvia'
 
+    # Civil holidays
+    include_labour_day = True
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (6, 23, "Midsummer Day"),
         (6, 24, "St. John's Day"),
         (11, 18, "Proclamation Day"),
         (12, 31, "New Years Eve"),
     )
 
+    # Christian holidays
     include_good_friday = True
     include_easter_sunday = True
     include_easter_monday = True

--- a/workalendar/europe/lithuania.py
+++ b/workalendar/europe/lithuania.py
@@ -6,14 +6,16 @@ from ..registry_tools import iso_register
 class Lithuania(WesternCalendar):
     'Lithuania'
 
+    # Civil holidays
+    include_labour_day = True
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (2, 16, "Restoration of the State Day"),
         (3, 11, "Restoration of Independence Day"),
-        (5, 1, "Labour Day"),
         (6, 24, "St. John's Day"),
         (7, 6, "Anniversary of the Coronation of King Mindaugas"),
     )
 
+    # Christian holidays
     include_easter_sunday = True
     include_easter_monday = True
     include_assumption = True

--- a/workalendar/europe/luxembourg.py
+++ b/workalendar/europe/luxembourg.py
@@ -7,6 +7,7 @@ from ..registry_tools import iso_register
 class Luxembourg(WesternCalendar):
     'Luxembourg'
 
+    # Christian holidays
     include_easter_monday = True
     include_ascension = True
     include_whit_monday = True
@@ -14,8 +15,9 @@ class Luxembourg(WesternCalendar):
     include_assumption = True
     include_boxing_day = True
 
+    # Civil holidays
+    include_labour_day = True
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (6, 23, "Luxembourg National Holiday"),
     )
 

--- a/workalendar/europe/malta.py
+++ b/workalendar/europe/malta.py
@@ -6,11 +6,15 @@ from ..registry_tools import iso_register
 class Malta(WesternCalendar):
     'Malta'
 
+    # Christian holidays
     include_good_friday = True
     include_assumption = True
     include_immaculate_conception = True
     include_christmas = True
 
+    # Civil holidays
+    include_labour_day = True
+    labour_day_label = "Worker's Day"  # (Jum il-Ħaddiem)
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         # National Holidays
         (3, 31, "Freedom Day"),            # (Jum il-Ħelsien)
@@ -21,6 +25,5 @@ class Malta(WesternCalendar):
         # Public Holidays
         (2, 10, "Feast of Saint Paul's Shipwreck"),
         (3, 19, "Feast of Saint Joseph"),  # (San Ġużepp)
-        (5, 1, "Worker's Day"),            # (Jum il-Ħaddiem)
         (6, 29, "Feast of Saint Peter & Saint Paul"),  # (L-Imnarja)
     )

--- a/workalendar/europe/norway.py
+++ b/workalendar/europe/norway.py
@@ -6,6 +6,7 @@ from ..registry_tools import iso_register
 class Norway(WesternCalendar):
     'Norway'
 
+    # Christian holidays
     include_holy_thursday = True
     include_good_friday = True
     include_easter_sunday = True
@@ -16,7 +17,8 @@ class Norway(WesternCalendar):
     include_boxing_day = True
     boxing_day_label = "St Stephen's Day"
 
+    # Civil holidays
+    include_labour_day = True
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (5, 17, "Constitution Day"),
     )

--- a/workalendar/europe/poland.py
+++ b/workalendar/europe/poland.py
@@ -6,12 +6,15 @@ from ..registry_tools import iso_register
 class Poland(WesternCalendar):
     'Poland'
 
+    # Civil holidays
+    include_labour_day = True
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (1, 6, 'Trzech Kroli'),
-        (5, 1, 'Labour Day'),
         (5, 3, 'Constitution Day'),
         (11, 11, 'Independence Day'),
     )
+
+    # Christian holidays
     include_easter_sunday = True
     include_easter_monday = True
     include_whit_sunday = True

--- a/workalendar/europe/portugal.py
+++ b/workalendar/europe/portugal.py
@@ -7,13 +7,16 @@ from ..registry_tools import iso_register
 class Portugal(WesternCalendar):
     'Portugal'
 
+    # Christian holidays
     include_good_friday = True
     include_easter_sunday = True
     include_christmas = True
 
+    # Civil holidays
+    include_labour_day = True
+    labour_day_label = "Dia do Trabalhador"
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (4, 25, "Dia da Liberdade"),
-        (5, 1, "Dia do Trabalhador"),
         (6, 10, "Dia de Portugal"),
         (8, 15, "Assunção de Nossa Senhora"),
         (12, 8, "Imaculada Conceição"),

--- a/workalendar/europe/romania.py
+++ b/workalendar/europe/romania.py
@@ -7,15 +7,17 @@ from ..registry_tools import iso_register
 class Romania(OrthodoxCalendar):
     'Romania'
 
+    # Civil holidays
+    include_labour_day = True
     FIXED_HOLIDAYS = OrthodoxCalendar.FIXED_HOLIDAYS + (
         (1, 2, "Day After New Year"),
         (1, 24, "Union Day"),
-        (5, 1, "Labour Day"),
         (8, 15, "Dormition of the Theotokos"),
         (11, 30, "St. Andrew's Day"),
         (12, 1, "National Day/Great Union"),
     )
 
+    # Christian holidays
     include_good_friday = True
     include_easter_sunday = True
     include_easter_monday = True

--- a/workalendar/europe/russia.py
+++ b/workalendar/europe/russia.py
@@ -8,12 +8,14 @@ class Russia(OrthodoxCalendar):
 
     shift_new_years_day = True
 
+    # Civil holidays
+    include_labour_day = True
+
     FIXED_HOLIDAYS = OrthodoxCalendar.FIXED_HOLIDAYS + (
         (1, 2, "Day After New Year"),
         (1, 7, "Christmas"),
         (2, 23, "Defendence of the Fatherland"),
         (3, 8, "International Women's Day"),
-        (5, 1, "Labour Day"),
         (5, 9, "Victory Day"),
         (6, 12, "National Day"),
         (11, 4, "Day of Unity"),

--- a/workalendar/europe/serbia.py
+++ b/workalendar/europe/serbia.py
@@ -11,11 +11,14 @@ class Serbia(OrthodoxCalendar):
         (1, 7, "Christmas"),
         (2, 15, "Statehood Day"),
         (2, 16, "Statehood Day"),
-        (5, 1, "Labour Day"),
         (5, 2, "Labour Day Holiday"),
         (11, 11, "Armistice Day"),
     )
 
+    # Civil holidays
+    include_labour_day = True
+
+    # Christian holidays
     include_good_friday = True
     include_easter_sunday = True
     include_easter_monday = True

--- a/workalendar/europe/slovakia.py
+++ b/workalendar/europe/slovakia.py
@@ -6,6 +6,7 @@ from ..registry_tools import iso_register
 class Slovakia(WesternCalendar):
     'Slovakia'
 
+    # Christian holidays
     include_epiphany = True
     include_easter_monday = True
     include_good_friday = True
@@ -14,9 +15,10 @@ class Slovakia(WesternCalendar):
     include_boxing_day = True
     boxing_day_label = "St. Stephen's Day (The Second Christmas Day)"
 
+    # Civil holidays
+    include_labour_day = True
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (1, 1, "Day of the Establishment of the Slovak Republic"),
-        (5, 1, "Labour Day"),
         (5, 8, "Liberation Day"),
         (7, 5, "Saints Cyril and Methodius Day"),
         (8, 29, "Slovak National Uprising anniversary"),

--- a/workalendar/europe/slovenia.py
+++ b/workalendar/europe/slovenia.py
@@ -7,17 +7,19 @@ from ..registry_tools import iso_register
 class Slovenia(WesternCalendar):
     'Slovenia'
 
+    # Christian holidays
     include_easter_sunday = True
     include_easter_monday = True
     include_whit_sunday = True
     include_assumption = True
     include_christmas = True
 
+    # Civil holidays
+    include_labour_day = True
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (2, 8, "Preseren Day, the Slovenian Cultural Holiday"),
         (4, 27, "Day of Uprising Against Occupation"),
-        (5, 1, "Labour Day"),
-        (5, 2, "Labour Day"),
+        (5, 2, "Labour Day"),  # In Slovenia, Labour Day is 2-day long.
         (6, 25, "Statehood Day"),
         (10, 31, "Reformation Day"),
         (11, 1, "Day of Remembrance of the Dead"),

--- a/workalendar/europe/spain.py
+++ b/workalendar/europe/spain.py
@@ -6,14 +6,17 @@ from ..registry_tools import iso_register
 class Spain(WesternCalendar):
     'Spain'
 
+    # Christian holidays
     include_epiphany = True
     include_immaculate_conception = True
     include_good_friday = True
     include_assumption = True
     include_all_saints = True
 
+    # Civil holidays
+    include_labour_day = True
+    labour_day_label = "Día del trabajador"
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Día del trabajador"),
         (10, 12, "Fiesta nacional de España"),
         (12, 6, "Día de la Constitución Española")
     )

--- a/workalendar/europe/sweden.py
+++ b/workalendar/europe/sweden.py
@@ -7,6 +7,7 @@ from ..registry_tools import iso_register
 class Sweden(WesternCalendar):
     'Sweden'
 
+    # Christian holidays
     include_epiphany = True
     include_good_friday = True
     include_easter_sunday = True
@@ -19,8 +20,9 @@ class Sweden(WesternCalendar):
     include_boxing_day = True
     boxing_day_label = "Second Day of Christmas"
 
+    # Civil holidays
+    include_labour_day = True
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, "Labour Day"),
         (6, 6, "National Day"),
         # New Year's Eve is not a holiday but not a work day either
         (12, 31, "New Year's Eve")

--- a/workalendar/europe/switzerland.py
+++ b/workalendar/europe/switzerland.py
@@ -27,7 +27,6 @@ class Switzerland(WesternCalendar):
     # Swiss entries with varying observance - opt in
     include_berchtolds_day = False
     include_st_josephs_day = False
-    include_labour_day = False
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (8, 1, "National Holiday"),
@@ -39,8 +38,6 @@ class Switzerland(WesternCalendar):
             days.append((date(year, 1, 2), "Berchtold's Day"))
         if self.include_st_josephs_day:
             days.append((date(year, 3, 19), "St Joseph's Day"))
-        if self.include_labour_day:
-            days.append((date(year, 5, 1), "Labour Day"))
         return days
 
 

--- a/workalendar/europe/turkey.py
+++ b/workalendar/europe/turkey.py
@@ -16,9 +16,11 @@ class Turkey(IslamicCalendar):
     include_eid_al_adha = True
     length_eid_al_adha = 4
 
+    # Civil holidays
+    include_labour_day = True
+    labour_day_label = "Labor and Solidarity Day"
     FIXED_HOLIDAYS = IslamicCalendar.FIXED_HOLIDAYS + (
         (4, 23, "National Sovereignty and Children's Day"),
-        (5, 1, "Labor and Solidarity Day"),
         (5, 19, "Commemoration of Atatürk, Youth and Sports Day"),
         (7, 15, "Democracy and National Unity Day"),
         (8, 30, "Victory Day"),

--- a/workalendar/europe/ukraine.py
+++ b/workalendar/europe/ukraine.py
@@ -12,10 +12,12 @@ class Ukraine(OrthodoxCalendar):
 
     FIXED_HOLIDAYS = OrthodoxCalendar.FIXED_HOLIDAYS + (
         (3, 8, "International Women’s Day"),
-        (5, 1, "Workers Solidarity Day"),
         (5, 9, "Victory Day"),
     )
-
+    # Civil holidays
+    include_labour_day = True
+    labour_day_label = "Workers Solidarity Day"
+    # Christian holidays
     include_christmas = False
     include_good_friday = True
     include_easter_sunday = True

--- a/workalendar/tests/test_africa.py
+++ b/workalendar/tests/test_africa.py
@@ -555,6 +555,12 @@ class AngolaTest(GenericCalendarTest):
         label_carnaval = holidays_dict[date(2018, 2, 13)]
         self.assertEqual(label_carnaval, "Dia de Carnaval")
 
+    def test_labour_day_label(self):
+        holidays = self.cal.holidays(2020)
+        holidays_dict = dict(holidays)
+        label = holidays_dict[date(2020, 5, 1)]
+        self.assertEqual(label, "Dia Internacional do Trabalhador")
+
 
 class KenyaTest(GenericCalendarTest):
     cal_class = Kenya

--- a/workalendar/tests/test_america.py
+++ b/workalendar/tests/test_america.py
@@ -124,6 +124,12 @@ class ArgentinaTest(GenericCalendarTest):
         label_carnival = holidays[date(2020, 2, 25)]
         self.assertEqual(label_carnival, "Carnival")
 
+    def test_labour_day_label(self):
+        holidays = self.cal.holidays(2020)
+        holidays = dict(holidays)
+        label = holidays[date(2020, 5, 1)]
+        self.assertEqual(label, "Día del Trabajador")
+
 
 class ChileTest(GenericCalendarTest):
     cal_class = Chile

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -437,6 +437,12 @@ class MalaysiaTest(GenericCalendarTest):
         # Back to normal, to avoid breaking further tests
         self.cal.MSIA_THAIPUSAM[2020] = save_2020
 
+    def test_labour_day_label(self):
+        holidays = self.cal.holidays(2020)
+        holidays = dict(holidays)
+        self.assertEqual(
+            holidays[date(2020, 5, 1)], "Workers' Day")
+
 
 class QatarTest(GenericCalendarTest):
     cal_class = Qatar

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -61,6 +61,12 @@ class AustriaTest(GenericCalendarTest):
         self.assertIn(date(2016, 12, 25), holidays)  # Xmas
         self.assertIn(date(2016, 12, 26), holidays)  # St Stephens
 
+    def test_labour_day_label(self):
+        holidays = self.cal.holidays(2020)
+        holidays = dict(holidays)
+        self.assertEqual(holidays[date(2020, 5, 1)], "State Holiday")
+        # a.k.a. Staatsfeiertag
+
 
 class BelarusTest(GenericCalendarTest):
     cal_class = Belarus
@@ -111,6 +117,12 @@ class BulgariaTest(GenericCalendarTest):
         self.assertIn(date(2016, 12, 26), holidays)   # Christmas 2
         # Non-attendance day for schools, otherwise a working day.
         self.assertNotIn(date(2016, 11, 1), holidays)   # National Awakening
+
+    def test_labour_day_label(self):
+        holidays = self.cal.holidays(2020)
+        holidays = dict(holidays)
+        self.assertEqual(
+            holidays[date(2020, 5, 1)], "International Workers' Day")
 
 
 class CaymanIslandsTest(GenericCalendarTest):
@@ -297,6 +309,12 @@ class CroatiaTest(GenericCalendarTest):
         self.assertNotIn(date(2019, 11, 18), holidays_2019)
         holidays_2020 = self.cal.holidays_set(2020)
         self.assertIn(date(2020, 11, 18), holidays_2020)
+
+    def test_labour_day_label(self):
+        holidays = self.cal.holidays(2020)
+        holidays = dict(holidays)
+        self.assertEqual(
+            holidays[date(2020, 5, 1)], "International Workers' Day")
 
 
 class Cyprus(GenericCalendarTest):
@@ -639,6 +657,12 @@ class MaltaTest(GenericCalendarTest):
         self.assertIn(date(2017, 12, 8), holidays)  # Il-Kunċizzjoni
         self.assertIn(date(2017, 12, 25), holidays)  # Il-Milied
 
+    def test_labour_day_label(self):
+        holidays = self.cal.holidays(2020)
+        holidays = dict(holidays)
+        self.assertEqual(
+            holidays[date(2020, 5, 1)], "Worker's Day")
+
 
 class NorwayTest(GenericCalendarTest):
     cal_class = Norway
@@ -783,6 +807,12 @@ class ItalyTest(GenericCalendarTest):
         self.assertIn(date(2013, 12, 8), holidays)  # immaculate Conception
         self.assertIn(date(2013, 12, 25), holidays)  # christmas
         self.assertIn(date(2013, 12, 26), holidays)  # San Stefano
+
+    def test_labour_day_label(self):
+        holidays = self.cal.holidays(2020)
+        holidays = dict(holidays)
+        self.assertEqual(
+            holidays[date(2020, 5, 1)], "International Workers' Day")
 
 
 class LatviaTest(GenericCalendarTest):
@@ -983,6 +1013,11 @@ class UkraineTest(GenericCalendarTest):
     def test_year_2018(self):
         holidays = self.cal.holidays_set(2018)
         self.assertNotIn(date(2018, 5, 2), holidays)  # Workers Solidarity Day
+
+    def test_may_1st_label(self):
+        holidays = self.cal.holidays(2020)
+        holidays = dict(holidays)
+        self.assertEqual(holidays[date(2020, 5, 1)], "Workers Solidarity Day")
 
 
 class UnitedKingdomTest(GenericCalendarTest):
@@ -1192,6 +1227,12 @@ class PortugalTest(GenericCalendarTest):
         # Restauração da Independência
         self.assertIn(date(2016, 12, 1), holidays)
 
+    def test_labour_day_label(self):
+        holidays = self.cal.holidays(2020)
+        holidays = dict(holidays)
+        self.assertEqual(
+            holidays[date(2020, 5, 1)], "Dia do Trabalhador")
+
 
 class SpainTest(GenericCalendarTest):
     cal_class = Spain
@@ -1217,6 +1258,12 @@ class SpainTest(GenericCalendarTest):
         self.assertIn(date(2016, 11, 1), holidays)
         self.assertIn(date(2016, 12, 6), holidays)
         self.assertIn(date(2016, 12, 8), holidays)
+
+    def test_labour_day_label(self):
+        holidays = self.cal.holidays(2020)
+        holidays = dict(holidays)
+        self.assertEqual(
+            holidays[date(2020, 5, 1)], "Día del trabajador")
 
 
 class CataloniaTest(GenericCalendarTest):
@@ -1254,6 +1301,12 @@ class CataloniaTest(GenericCalendarTest):
         self.assertIn(date(2016, 12, 8), holidays)
         self.assertIn(date(2016, 12, 25), holidays)
         self.assertIn(date(2016, 12, 26), holidays)
+
+    def test_labour_day_label(self):
+        holidays = self.cal.holidays(2020)
+        holidays = dict(holidays)
+        self.assertEqual(
+            holidays[date(2020, 5, 1)], "Día del trabajador")
 
 
 class SerbiaTest(GenericCalendarTest):

--- a/workalendar/tests/test_turkey.py
+++ b/workalendar/tests/test_turkey.py
@@ -79,3 +79,9 @@ class TurkeyTest(GenericCalendarTest):
         self.assertIn(date(2019, 8, 12), holidays)
         self.assertIn(date(2019, 8, 13), holidays)
         self.assertIn(date(2019, 8, 14), holidays)
+
+    def test_labour_day_label(self):
+        holidays = self.cal.holidays(2020)
+        holidays = dict(holidays)
+        self.assertEqual(
+            holidays[date(2020, 5, 1)], "Labor and Solidarity Day")


### PR DESCRIPTION
* Labour Day is handled at the higher level (`core.Calendar`).
* Generalized this flag + optional label to 50 countries: Algeria, Angola, Argentina, Austria, Barbados, Belarus, Belgium, Benin, Brazil, Bulgaria, Chile, Colombia, Croatia, Cyprus, Czech Republic, European Central Bank, Finland, France, Germany, Greece, Hong-Kong, Hungary, Iceland, Italy, Ivory Coast, Kenya, Latvia, Lithuania, Luxembourg, Madagascar, Malaysia, Malta, Mexico, Norway, Panama, Paraguay, Poland, Portugal, Romania, Russia, Sao Tome & Principe, Serbia, Singapore, Slovakia, Slovenia, Spain (incl. Catalonia), Sweden, Switzerland, Turkey, Ukraine.
* Contributing documentation amended

closes #467


- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
