### PR TITLE
Replace occurrences of `assertEquals` with `assertEqual` to clear warnings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Small refactoring for the Colombia / added docstrings & comments to explain why we're not using stock options. Added tests for year 2020 and handling shift exceptions (#509).
 - Migrating Labour Day as a worldwide holiday, disabled by default, but activated (to date) for about 50 countries (including label change when necessary), `contributing.md` documentation amended (#467).
+- Tech: Replace occurrences of `assertEquals` with `assertEqual` to clear warnings (#533).
 
 ## v10.3.0 (2020-07-10)
 

--- a/workalendar/tests/test_africa.py
+++ b/workalendar/tests/test_africa.py
@@ -581,7 +581,7 @@ class KenyaTest(GenericCalendarTest):
         self.assertIn(date(2019, 12, 25), holidays)  # Christmas Day
         self.assertIn(date(2019, 12, 26), holidays)  # Boxing Day (old name)
         self.assertIn(date(2019, 12, 31), holidays)  # New Years Eve
-        self.assertEquals(len(holidays), 14)
+        self.assertEqual(len(holidays), 14)
 
     def test_year_2020(self):
         holidays = self.cal.holidays_set(2020)
@@ -599,4 +599,4 @@ class KenyaTest(GenericCalendarTest):
         self.assertIn(date(2020, 12, 25), holidays)  # Christmas Day
         self.assertIn(date(2020, 12, 26), holidays)  # Utamaduni Day
         self.assertIn(date(2020, 12, 31), holidays)  # New Years Eve
-        self.assertEquals(len(holidays), 14)
+        self.assertEqual(len(holidays), 14)

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -866,78 +866,78 @@ class BrazilBankCalendarTest(BrazilTest):
         self.assertIn(date(2017, 11, 15), holidays)  # Republic day
         self.assertIn(date(2017, 12, 25), holidays)  # Christmas Day
         self.assertIn(date(2017, 12, 29), holidays)  # Last working day of year
-        self.assertEquals(14, len(holidays))
+        self.assertEqual(14, len(holidays))
 
     def test_year_2017_find_next_working_day_for_new_year(self):
         new_year = date(2017, 1, 1)
         working_day = self.cal.find_following_working_day(new_year)
-        self.assertEquals(working_day, date(2017, 1, 2))
+        self.assertEqual(working_day, date(2017, 1, 2))
 
     def test_year_2017_find_next_working_day_for_monday_carnaval(self):
         monday_carnaval = date(2017, 2, 27)
         working_day = self.cal.find_following_working_day(monday_carnaval)
-        self.assertEquals(working_day, date(2017, 3, 2))
+        self.assertEqual(working_day, date(2017, 3, 2))
 
     def test_year_2017_find_next_working_day_for_tuesday_carnaval(self):
         tuesday_carnaval = date(2017, 2, 28)
         working_day = self.cal.find_following_working_day(tuesday_carnaval)
-        self.assertEquals(working_day, date(2017, 3, 2))
+        self.assertEqual(working_day, date(2017, 3, 2))
 
     def test_year_2017_find_next_working_day_for_good_friday(self):
         good_friday = date(2017, 4, 14)
         working_day = self.cal.find_following_working_day(good_friday)
-        self.assertEquals(working_day, date(2017, 4, 17))
+        self.assertEqual(working_day, date(2017, 4, 17))
 
     def test_year_2017_find_next_working_day_for_tiradentes(self):
         tiradentes = date(2017, 4, 21)
         working_day = self.cal.find_following_working_day(tiradentes)
-        self.assertEquals(working_day, date(2017, 4, 24))
+        self.assertEqual(working_day, date(2017, 4, 24))
 
     def test_year_2017_find_next_working_day_for_labour_day(self):
         labour_day = date(2017, 5, 1)
         working_day = self.cal.find_following_working_day(labour_day)
-        self.assertEquals(working_day, date(2017, 5, 2))
+        self.assertEqual(working_day, date(2017, 5, 2))
 
     def test_year_2017_find_next_working_day_for_corpus_christi(self):
         corpus_christi = date(2017, 6, 15)
         working_day = self.cal.find_following_working_day(corpus_christi)
-        self.assertEquals(working_day, date(2017, 6, 16))
+        self.assertEqual(working_day, date(2017, 6, 16))
 
     def test_year_2017_find_next_working_day_for_independence_day(self):
         independence_day = date(2017, 9, 7)
         working_day = self.cal.find_following_working_day(independence_day)
-        self.assertEquals(working_day, date(2017, 9, 8))
+        self.assertEqual(working_day, date(2017, 9, 8))
 
     def test_year_2017_find_next_working_day_for_our_lady_aparecida(self):
         our_lady_aparecida = date(2017, 10, 12)
         working_day = self.cal.find_following_working_day(our_lady_aparecida)
-        self.assertEquals(working_day, date(2017, 10, 13))
+        self.assertEqual(working_day, date(2017, 10, 13))
 
     def test_year_2017_find_next_working_day_for_our_all_souls(self):
         all_souls = date(2017, 11, 2)
         working_day = self.cal.find_following_working_day(all_souls)
-        self.assertEquals(working_day, date(2017, 11, 3))
+        self.assertEqual(working_day, date(2017, 11, 3))
 
     def test_year_2017_find_next_working_day_for_our_republic_day(self):
         republic_day = date(2017, 11, 15)
         working_day = self.cal.find_following_working_day(republic_day)
-        self.assertEquals(working_day, date(2017, 11, 16))
+        self.assertEqual(working_day, date(2017, 11, 16))
 
     def test_year_2017_find_next_working_day_for_our_christmas_day(self):
         christmas_day = date(2017, 12, 25)
         working_day = self.cal.find_following_working_day(christmas_day)
-        self.assertEquals(working_day, date(2017, 12, 26))
+        self.assertEqual(working_day, date(2017, 12, 26))
 
     def test_year_2017_find_next_working_day_for_last_day(self):
         # last day of year for only internal bank transactions
         last_day = date(2017, 12, 29)
         working_day = self.cal.find_following_working_day(last_day)
-        self.assertEquals(working_day, date(2018, 1, 2))
+        self.assertEqual(working_day, date(2018, 1, 2))
 
     def test_year_2017_find_next_working_day_for_already_working_day(self):
         already_working_day = date(2017, 7, 25)
         working_day = self.cal.find_following_working_day(already_working_day)
-        self.assertEquals(working_day, date(2017, 7, 25))
+        self.assertEqual(working_day, date(2017, 7, 25))
 
     def test_carnaval_label(self):
         holidays = self.cal.holidays(2017)

--- a/workalendar/tests/test_core.py
+++ b/workalendar/tests/test_core.py
@@ -29,12 +29,12 @@ class CalendarTest(CoreCalendarTest):
     def test_year(self):
         holidays = self.cal.holidays()
         self.assertTrue(isinstance(holidays, (tuple, list)))
-        self.assertEquals(self.cal._holidays[self.year], holidays)
+        self.assertEqual(self.cal._holidays[self.year], holidays)
 
     def test_another_year(self):
         holidays = self.cal.holidays(2011)
         self.assertTrue(isinstance(holidays, (tuple, list)))
-        self.assertEquals(self.cal._holidays[2011], holidays)
+        self.assertEqual(self.cal._holidays[2011], holidays)
 
     def test_is_working_day(self):
         self.assertRaises(
@@ -43,23 +43,23 @@ class CalendarTest(CoreCalendarTest):
 
     def test_nth_weekday(self):
         # first monday in january 2013
-        self.assertEquals(
+        self.assertEqual(
             Calendar.get_nth_weekday_in_month(2013, 1, MON),
             date(2013, 1, 7)
         )
         # second monday in january 2013
-        self.assertEquals(
+        self.assertEqual(
             Calendar.get_nth_weekday_in_month(2013, 1, MON, 2),
             date(2013, 1, 14)
         )
         # let's test the limits
         # Jan 1st is a TUE
-        self.assertEquals(
+        self.assertEqual(
             Calendar.get_nth_weekday_in_month(2013, 1, TUE),
             date(2013, 1, 1)
         )
         # There's no 6th MONday
-        self.assertEquals(
+        self.assertEqual(
             Calendar.get_nth_weekday_in_month(2013, 1, MON, 6),
             None
         )
@@ -67,38 +67,38 @@ class CalendarTest(CoreCalendarTest):
     def test_nth_weekday_start(self):
         # first thursday after 18th april
         start = date(2013, 4, 18)
-        self.assertEquals(
+        self.assertEqual(
             Calendar.get_nth_weekday_in_month(2013, 4, THU, start=start),
             date(2013, 4, 18)
         )
         # first friday after 18th april
         start = date(2013, 4, 18)
-        self.assertEquals(
+        self.assertEqual(
             Calendar.get_nth_weekday_in_month(2013, 4, FRI, start=start),
             date(2013, 4, 19)
         )
 
     def test_last_weekday(self):
         # last monday in january 2013
-        self.assertEquals(
+        self.assertEqual(
             Calendar.get_last_weekday_in_month(2013, 1, MON),
             date(2013, 1, 28)
         )
         # last thursday
-        self.assertEquals(
+        self.assertEqual(
             Calendar.get_last_weekday_in_month(2013, 1, THU),
             date(2013, 1, 31)
         )
 
     def test_get_next_weekday_after(self):
         # the first monday after Apr 1 2015
-        self.assertEquals(
+        self.assertEqual(
             Calendar.get_first_weekday_after(date(2015, 4, 1), MON),
             date(2015, 4, 6)
         )
 
         # the first tuesday after Apr 14 2015
-        self.assertEquals(
+        self.assertEqual(
             Calendar.get_first_weekday_after(date(2015, 4, 14), TUE),
             date(2015, 4, 14)
         )
@@ -107,7 +107,7 @@ class CalendarTest(CoreCalendarTest):
 class LunarCalendarTest(TestCase):
 
     def test_lunar_new_year(self):
-        self.assertEquals(
+        self.assertEqual(
             LunarMixin.lunar(2014, 1, 1),
             date(2014, 1, 31)
         )
@@ -144,26 +144,26 @@ class MockCalendarTest(CoreCalendarTest):
 
     def test_add_workingdays_simple(self):
         # day is out of non-working-day
-        self.assertEquals(
+        self.assertEqual(
             self.cal.add_working_days(date(self.year, 12, 20), 0),
             date(self.year, 12, 20)
         )
-        self.assertEquals(
+        self.assertEqual(
             self.cal.add_working_days(date(self.year, 12, 20), 1),
             date(self.year, 12, 21)
         )
 
     def test_add_workingdays_on_holiday(self):
         # day is in holidays
-        self.assertEquals(
+        self.assertEqual(
             self.cal.add_working_days(date(self.year, 12, 25), 0),
             date(self.year, 12, 25)
         )
-        self.assertEquals(
+        self.assertEqual(
             self.cal.add_working_days(date(self.year, 12, 24), 1),
             date(self.year, 12, 26)
         )
-        self.assertEquals(
+        self.assertEqual(
             self.cal.add_working_days(date(self.year, 12, 24), 2),
             date(self.year, 12, 27)
         )
@@ -171,7 +171,7 @@ class MockCalendarTest(CoreCalendarTest):
     def test_add_workingdays_span(self):
         day = date(self.year, 12, 20)
         # since this calendar has no weekends, we'll just have a 2-day-shift
-        self.assertEquals(
+        self.assertEqual(
             self.cal.add_working_days(day, 20),
             date(self.year + 1, 1, 11)
         )
@@ -181,12 +181,12 @@ class MockCalendarTest(CoreCalendarTest):
         christmas = date(self.year, 12, 25)
         boxing = date(self.year, 12, 26)
         # exceptional workday
-        self.assertEquals(
+        self.assertEqual(
             self.cal.add_working_days(day, 20, extra_working_days=[christmas]),
             date(self.year + 1, 1, 10)
         )
         # exceptional holiday + exceptional workday
-        self.assertEquals(
+        self.assertEqual(
             self.cal.add_working_days(day, 20,
                                       extra_working_days=[christmas],
                                       extra_holidays=[boxing]),
@@ -223,16 +223,16 @@ class MockCalendarTest(CoreCalendarTest):
     def test_add_working_days_backwards(self):
         day = date(self.year, 1, 3)
         # since this calendar has no weekends, we'll just have a 1-day-shift
-        self.assertEquals(
+        self.assertEqual(
             self.cal.add_working_days(day, -7),
             date(self.year - 1, 12, 26)
         )
-        self.assertEquals(
+        self.assertEqual(
             self.cal.sub_working_days(day, 7),
             date(self.year - 1, 12, 26)
         )
         # Negative argument to sub_working_days -> converted to positive.
-        self.assertEquals(
+        self.assertEqual(
             self.cal.sub_working_days(day, -7),
             date(self.year - 1, 12, 26)
         )
@@ -243,7 +243,7 @@ class IslamicMixinTest(CoreCalendarTest):
 
     def test_year_conversion(self):
         days = self.cal.converted(2013)
-        self.assertEquals(len(days), 365)
+        self.assertEqual(len(days), 365)
 
 
 class JalaliMixinTest(CoreCalendarTest):
@@ -251,7 +251,7 @@ class JalaliMixinTest(CoreCalendarTest):
 
     def test_year_conversion(self):
         days = self.cal.converted(2013)
-        self.assertEquals(len(days), 365)
+        self.assertEqual(len(days), 365)
 
 
 class MockChristianCalendar(WesternCalendar):
@@ -287,7 +287,7 @@ class MockChristianCalendarTest(CoreCalendarTest):
         self.assertIn(date(2014, 12, 25), holidays)  # XMas
 
         # Only 2 days: Jan 1st and Christmas
-        self.assertEquals(len(holidays), 2)
+        self.assertEqual(len(holidays), 2)
 
 
 class NoWeekendCalendar(Calendar):
@@ -584,25 +584,25 @@ class TestAcceptableDateTypes(CoreCalendarTest):
 
     def test_add_working_days_datetime(self):
         # datetime inside, date outside
-        self.assertEquals(
+        self.assertEqual(
             self.cal.add_working_days(
                 datetime(self.year, 12, 20, 12, 34, 56), 0),
             date(self.year, 12, 20)
         )
-        self.assertEquals(
+        self.assertEqual(
             self.cal.add_working_days(
                 datetime(self.year, 12, 20, 12, 34, 56), 1),
             date(self.year, 12, 21)
         )
 
         # Use the `keep_datetime` option
-        self.assertEquals(
+        self.assertEqual(
             self.cal.add_working_days(
                 datetime(self.year, 12, 20, 12, 34, 56),
                 0, keep_datetime=True),
             datetime(self.year, 12, 20, 12, 34, 56)
         )
-        self.assertEquals(
+        self.assertEqual(
             self.cal.add_working_days(
                 datetime(self.year, 12, 20, 12, 34, 56),
                 1, keep_datetime=True),
@@ -611,25 +611,25 @@ class TestAcceptableDateTypes(CoreCalendarTest):
 
     def test_sub_working_days_datetime(self):
         # datetime inside, date outside
-        self.assertEquals(
+        self.assertEqual(
             self.cal.sub_working_days(
                 datetime(self.year, 12, 20, 12, 34, 56), 0),
             date(self.year, 12, 20)
         )
-        self.assertEquals(
+        self.assertEqual(
             self.cal.sub_working_days(
                 datetime(self.year, 12, 20, 12, 34, 56), 1),
             date(self.year, 12, 19)
         )
 
         # Use the `keep_datetime` option
-        self.assertEquals(
+        self.assertEqual(
             self.cal.sub_working_days(
                 datetime(self.year, 12, 20, 12, 34, 56),
                 0, keep_datetime=True),
             datetime(self.year, 12, 20, 12, 34, 56)
         )
-        self.assertEquals(
+        self.assertEqual(
             self.cal.sub_working_days(
                 datetime(self.year, 12, 20, 12, 34, 56),
                 1, keep_datetime=True),

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -540,12 +540,12 @@ class FranceTest(GenericCalendarTest):
 
     def test_business_days_computations(self):
         day = date(2013, 10, 30)
-        self.assertEquals(
+        self.assertEqual(
             self.cal.add_working_days(day, 0), date(2013, 10, 30))
-        self.assertEquals(
+        self.assertEqual(
             self.cal.add_working_days(day, 1), date(2013, 10, 31))
-        self.assertEquals(self.cal.add_working_days(day, 2), date(2013, 11, 4))
-        self.assertEquals(self.cal.add_working_days(day, 3), date(2013, 11, 5))
+        self.assertEqual(self.cal.add_working_days(day, 2), date(2013, 11, 4))
+        self.assertEqual(self.cal.add_working_days(day, 3), date(2013, 11, 5))
 
 
 class FranceAlsaceMoselleTest(FranceTest):


### PR DESCRIPTION


closes #533

- [x] No regression in tests
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
