### PR TITLE
Use `include_immaculate_conception` flag for Portugal, Brazil, Argentina & Paraguay calendars

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Small refactoring for the Colombia / added docstrings & comments to explain why we're not using stock options. Added tests for year 2020 and handling shift exceptions (#509).
 - Migrating Labour Day as a worldwide holiday, disabled by default, but activated (to date) for about 50 countries (including label change when necessary), `contributing.md` documentation amended (#467).
 - Tech: Replace occurrences of `assertEquals` with `assertEqual` to clear warnings (#533).
+- Use `include_immaculate_conception` flag for Portugal, Brazil, Argentina, Paraguay calendars (#529).
 
 ## v10.3.0 (2020-07-10)
 

--- a/workalendar/america/argentina.py
+++ b/workalendar/america/argentina.py
@@ -16,13 +16,14 @@ class Argentina(WesternCalendar):
     include_easter_saturday = True
     include_easter_sunday = True
     include_christmas = True
+    include_immaculate_conception = True
+    immaculate_conception_label = "Día de la Inmaculada Concepción de María"
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (3, 24, "Día Nacional de la Memoria por la Verdad y la Justicia"),
         (5, 25, "Día de la Revolución de Mayo"),
         (6, 20, "Día Paso a la Inmortalidad del General Manuel Belgrano"),
         (7, 9, "Día de la Independencia"),
-        (12, 8, "Día de la Inmaculada Concepción de María"),
     )
 
     def get_general_guemes_day(self, year):
@@ -125,25 +126,17 @@ class Argentina(WesternCalendar):
         return (day, label)
 
     def get_variable_days(self, year):
-
         days = super().get_variable_days(year)
         days.append(
             (self.get_easter_sunday(year) - timedelta(days=48),
                 "Carnival Lunes"))
 
-        days.append(
-            self.get_malvinas_day(year))
-
-        days.append(
-            (self.get_general_guemes_day(year)))
-
-        days.append(
-            (self.get_general_martin_day(year)))
-
-        days.append(
-            (self.get_soberania_day(year)))
-
-        days.append(
-            (self.get_diversidad_day(year)))
+        days.extend([
+            self.get_malvinas_day(year),
+            self.get_general_guemes_day(year),
+            self.get_general_martin_day(year),
+            self.get_soberania_day(year),
+            self.get_diversidad_day(year)
+        ])
 
         return days

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -30,9 +30,12 @@ class Brazil(WesternCalendar):
     # The most common is November, 20th
     consciencia_negra_day = (11, 20)
     consciencia_negra_label = "Consciência Negra"
-    include_nossa_senhora_conceicao = False
+
     # Christian holidays
     include_easter_sunday = True
+    # Dia de Nossa Senhora da Conceição is the Immaculate Conception.
+    include_immaculate_conception = False
+    immaculate_conception_label = "Dia de Nossa Senhora da Conceição"
 
     def get_variable_days(self, year):
         days = super().get_variable_days(year)
@@ -48,10 +51,6 @@ class Brazil(WesternCalendar):
             month, day = self.consciencia_negra_day
             days.append(
                 (date(year, month, day), self.consciencia_negra_label)
-            )
-        if self.include_nossa_senhora_conceicao:
-            days.append(
-                (date(year, 12, 8), "Dia de Nossa Senhora da Conceição")
             )
         return days
 
@@ -99,7 +98,7 @@ class BrazilAmazonas(Brazil):
         (9, 5, "Elevação do Amazonas á categoria de província"),
     )
     include_consciencia_negra = True
-    include_nossa_senhora_conceicao = True
+    include_immaculate_conception = True
 
 
 @iso_register('BR-BA')
@@ -147,7 +146,7 @@ class BrazilMaranhao(Brazil):
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
         (7, 28, "Adesão do Maranhão á independência do Brasil"),
     )
-    include_nossa_senhora_conceicao = True
+    include_immaculate_conception = True
 
 
 @iso_register('BR-MG')
@@ -179,7 +178,7 @@ class BrazilPara(Brazil):
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
         (8, 15, "Adesão do Grão-Pará á independência do Brasil"),
     )
-    include_nossa_senhora_conceicao = True
+    include_immaculate_conception = True
 
 
 @iso_register('BR-PB')
@@ -230,7 +229,7 @@ class BrazilRioDeJaneiro(Brazil):
     servidor_publico_label = "Dia do Funcionário Público"
     include_consciencia_negra = True
     consciencia_negra_label = "Dia da Consciência Negra"
-    include_nossa_senhora_conceicao = True
+    include_immaculate_conception = True
 
     def get_dia_do_comercio(self, year):
         """
@@ -371,7 +370,7 @@ class BrazilGuarapariCity(BrazilEspiritoSanto):
     include_sao_pedro = True
     include_consciencia_negra = True
     consciencia_negra_day = (11, 29)
-    include_nossa_senhora_conceicao = True
+    include_immaculate_conception = True
 
 
 class BrazilSerraCity(BrazilEspiritoSanto):
@@ -386,7 +385,7 @@ class BrazilSerraCity(BrazilEspiritoSanto):
     include_good_friday = True
     good_friday_label = "Paixão do Cristo"
     include_sao_pedro = True
-    include_nossa_senhora_conceicao = True
+    include_immaculate_conception = True
 
     def get_variable_days(self, year):
         days = super().get_variable_days(year)

--- a/workalendar/america/paraguay.py
+++ b/workalendar/america/paraguay.py
@@ -11,7 +11,6 @@ class Paraguay(WesternCalendar):
         (5, 14, "Independence Day"),
         (6, 12, "Chaco Armistice"),
         (9, 19, "Army holiday"),
-        (12, 8, "Virgin of Caacupé Day"),
     )
     # Civil holidays
     include_labour_day = True
@@ -19,6 +18,8 @@ class Paraguay(WesternCalendar):
     include_holy_thursday = True
     include_good_friday = True
     include_easter_saturday = True
+    include_immaculate_conception = True
+    immaculate_conception_label = "Virgin of Caacupé Day"
 
     def get_heroes_day(self, year):
         """

--- a/workalendar/europe/portugal.py
+++ b/workalendar/europe/portugal.py
@@ -11,6 +11,8 @@ class Portugal(WesternCalendar):
     include_good_friday = True
     include_easter_sunday = True
     include_christmas = True
+    include_immaculate_conception = True
+    immaculate_conception_label = "Imaculada Conceição"
 
     # Civil holidays
     include_labour_day = True
@@ -19,7 +21,6 @@ class Portugal(WesternCalendar):
         (4, 25, "Dia da Liberdade"),
         (6, 10, "Dia de Portugal"),
         (8, 15, "Assunção de Nossa Senhora"),
-        (12, 8, "Imaculada Conceição"),
     )
 
     def get_fixed_holidays(self, year):

--- a/workalendar/tests/test_america.py
+++ b/workalendar/tests/test_america.py
@@ -130,6 +130,12 @@ class ArgentinaTest(GenericCalendarTest):
         label = holidays[date(2020, 5, 1)]
         self.assertEqual(label, "Día del Trabajador")
 
+    def test_immaculate_conception_label(self):
+        holidays = self.cal.holidays(2020)
+        holidays = dict(holidays)
+        label = holidays[date(2020, 12, 8)]
+        self.assertEqual(label, "Día de la Inmaculada Concepción de María")
+
 
 class ChileTest(GenericCalendarTest):
     cal_class = Chile
@@ -347,6 +353,12 @@ class ParaguayTest(GenericCalendarTest):
         # Boqueron Battle Victory Day: moved to October 2nd for 2017
         self.assertNotIn(date(2017, 9, 29), holidays)
         self.assertIn(date(2017, 10, 2), holidays)
+
+    def test_immaculate_conception_label(self):
+        holidays = self.cal.holidays(2020)
+        holidays = dict(holidays)
+        label = holidays[date(2020, 12, 8)]
+        self.assertEqual(label, "Virgin of Caacupé Day")
 
 
 class BarbadosTest(GenericCalendarTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -31,6 +31,7 @@ from ..america.brazil import IBGE_REGISTER, IBGE_TUPLE
 class BrazilTest(GenericCalendarTest):
     cal_class = Brazil
     test_include_consciencia_negra = False
+    test_include_immaculate_conception = False
 
     def test_year_2013_federal(self):
         holidays = self.cal.holidays_set(2013)
@@ -56,6 +57,23 @@ class BrazilTest(GenericCalendarTest):
         else:
             # By default, not in the holidays.
             self.assertNotIn(consciencia_negra_day, holidays)
+
+    def test_immaculate_conception(self):
+        # Immaculate Conception is not a national holiday
+        # It's triggered in the appropriate classes, so this test needs to
+        # be overwritten.
+        immaculate_conception_day = date(self.year, 12, 8)
+        holidays = dict(self.cal.holidays(self.year))
+        if self.test_include_immaculate_conception:
+            # Included where needed
+            self.assertIn(immaculate_conception_day, holidays)
+            # Test its label
+            self.assertEqual(
+                holidays[immaculate_conception_day],
+                "Dia de Nossa Senhora da Conceição")
+        else:
+            # By default, not in the holidays.
+            self.assertNotIn(immaculate_conception_day, holidays)
 
 
 class BrazilAcreTest(BrazilTest):
@@ -107,6 +125,7 @@ class BrazilAmapaTest(BrazilTest):
 class BrazilAmazonasTest(BrazilTest):
     cal_class = BrazilAmazonas
     test_include_consciencia_negra = True
+    test_include_immaculate_conception = True
 
     def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
@@ -115,6 +134,8 @@ class BrazilAmazonasTest(BrazilTest):
         self.assertIn(date(2017, 11, 20), holidays)  # Consciência Negra
         # Dia de Nossa Senhora da Conceição
         self.assertIn(date(2017, 12, 8), holidays)
+        # Label test
+        holidays = self.cal.holidays(2017)
 
 
 class BrazilBahiaTest(BrazilTest):
@@ -162,6 +183,7 @@ class BrazilGoiasTest(BrazilTest):
 
 class BrazilMaranhaoTest(BrazilTest):
     cal_class = BrazilMaranhao
+    test_include_immaculate_conception = True
 
     def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
@@ -199,6 +221,7 @@ class BrazilMatoGrossoDoSulTest(BrazilTest):
 
 class BrazilParaTest(BrazilTest):
     cal_class = BrazilPara
+    test_include_immaculate_conception = True
 
     def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
@@ -246,6 +269,7 @@ class BrazilParanaTest(BrazilTest):
 class BrazilRioDeJaneiroTest(BrazilTest):
     cal_class = BrazilRioDeJaneiro
     test_include_consciencia_negra = True
+    test_include_immaculate_conception = True
 
     def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
@@ -471,6 +495,7 @@ class BrazilGuarapariCityTest(BrazilEspiritoSantoTest):
     """
     cal_class = BrazilGuarapariCity
     test_include_consciencia_negra = True
+    test_include_immaculate_conception = True
 
     def test_year_2017_city(self):
         holidays = self.cal.holidays_set(2017)
@@ -485,6 +510,7 @@ class BrazilSerraCityTest(BrazilEspiritoSantoTest):
     Serra city is in the Espírito Santo state
     """
     cal_class = BrazilSerraCity
+    test_include_immaculate_conception = True
 
     def test_year_2017_city(self):
         holidays = self.cal.holidays_set(2017)

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -1233,6 +1233,11 @@ class PortugalTest(GenericCalendarTest):
         self.assertEqual(
             holidays[date(2020, 5, 1)], "Dia do Trabalhador")
 
+    def test_immaculate_conception_label(self):
+        holidays = self.cal.holidays(2020)
+        holidays = dict(holidays)
+        self.assertEqual(holidays[date(2020, 12, 8)], "Imaculada Conceição")
+
 
 class SpainTest(GenericCalendarTest):
     cal_class = Spain


### PR DESCRIPTION
closes #529

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
