### PR TITLE
add monaco holidays

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 - Migrating Labour Day as a worldwide holiday, disabled by default, but activated (to date) for about 50 countries (including label change when necessary), `contributing.md` documentation amended (#467).
 - Tech: Replace occurrences of `assertEquals` with `assertEqual` to clear warnings (#533).
 - Use `include_immaculate_conception` flag for Portugal, Brazil, Argentina, Paraguay calendars (#529).
+- Added Monaco by @joaopbnogueira
 
 ## v10.3.0 (2020-07-10)
 

--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,7 @@ Europe
 * Lithuania
 * Luxembourg
 * Malta
+* Monaco
 * Netherlands
 * Norway
 * Poland

--- a/workalendar/europe/__init__.py
+++ b/workalendar/europe/__init__.py
@@ -20,6 +20,7 @@ from .latvia import Latvia
 from .lithuania import Lithuania
 from .luxembourg import Luxembourg
 from .malta import Malta
+from .monaco import Monaco
 from .netherlands import Netherlands
 from .norway import Norway
 from .poland import Poland
@@ -85,6 +86,7 @@ __all__ = (
     'Lithuania',
     'Luxembourg',
     'Malta',
+    'Monaco',
     'Netherlands',
     'Norway',
     'Poland',

--- a/workalendar/europe/monaco.py
+++ b/workalendar/europe/monaco.py
@@ -1,0 +1,23 @@
+from ..core import WesternCalendar
+from ..registry_tools import iso_register
+
+
+@iso_register('MC')
+class Monaco(WesternCalendar):
+    'Monaco'
+
+    # Christian holidays
+    include_easter_monday = True
+    include_ascension = True
+    include_whit_monday = True
+    include_all_saints = True
+    include_assumption = True
+    include_corpus_christi = True
+    include_immaculate_conception = True
+
+    # Civil holidays
+    include_labour_day = True
+    FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
+        (1, 27, "Saint Dévote's Day"),
+        (11, 19, "H.S.H. the Sovereign Prince's Day"),
+    )

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -26,6 +26,7 @@ from ..europe import (
     Lithuania,
     Luxembourg,
     Malta,
+    Monaco,
     Netherlands,
     Norway,
     Poland,
@@ -662,6 +663,42 @@ class MaltaTest(GenericCalendarTest):
         holidays = dict(holidays)
         self.assertEqual(
             holidays[date(2020, 5, 1)], "Worker's Day")
+
+
+class MonacoTest(GenericCalendarTest):
+    cal_class = Monaco
+
+    def test_year_2020(self):
+        holidays = self.cal.holidays_set(2020)
+        # National Holidays
+        self.assertIn(date(2020, 1, 1), holidays)  # New Year's Day
+        self.assertIn(date(2020, 1, 27), holidays)  # Saint Dévote's Day
+        self.assertIn(date(2020, 4, 13), holidays)  # Easter Monday
+        self.assertIn(date(2020, 5, 1), holidays)  # Labour Day
+        self.assertIn(date(2020, 5, 21), holidays)  # Ascension Day
+        self.assertIn(date(2020, 6, 1), holidays)  # Whit Monday
+        self.assertIn(date(2020, 6, 11), holidays)  # Corpus Christi
+        self.assertIn(date(2020, 8, 15), holidays)  # Assumption Day
+        self.assertIn(date(2020, 11, 1), holidays)  # All Saints' Day
+        self.assertIn(date(2020, 11, 19), holidays)  # Sovereign Prince's Day
+        self.assertIn(date(2020, 12, 8), holidays)  # Conception Day
+        self.assertIn(date(2020, 12, 25), holidays)  # Christmas Day
+
+    def test_year_2018(self):
+        holidays = self.cal.holidays_set(2018)
+        # National Holidays
+        self.assertIn(date(2018, 1, 1), holidays)  # New Year's Day
+        self.assertIn(date(2018, 1, 27), holidays)  # Saint Dévote's Day
+        self.assertIn(date(2018, 4, 2), holidays)  # Easter Monday
+        self.assertIn(date(2018, 5, 1), holidays)  # Labour Day
+        self.assertIn(date(2018, 5, 10), holidays)  # Ascension Day
+        self.assertIn(date(2018, 5, 21), holidays)  # Whit Monday
+        self.assertIn(date(2018, 5, 31), holidays)  # Corpus Christi
+        self.assertIn(date(2018, 8, 15), holidays)  # Assumption Day
+        self.assertIn(date(2018, 11, 1), holidays)  # All Saints' Day
+        self.assertIn(date(2018, 11, 19), holidays)  # Sovereign Prince's Day
+        self.assertIn(date(2018, 12, 8), holidays)  # Conception Day
+        self.assertIn(date(2018, 12, 25), holidays)  # Christmas Day
 
 
 class NorwayTest(GenericCalendarTest):

--- a/workalendar/tests/test_registry_europe.py
+++ b/workalendar/tests/test_registry_europe.py
@@ -4,8 +4,8 @@ from ..europe import (
     Denmark, Finland, France,
     # FranceAlsaceMoselle,  # TODO: Should we add it to the registry?
     Greece, Hungary, Iceland, Ireland, Italy, Latvia, Lithuania, Luxembourg,
-    Malta, Netherlands, Norway, Poland, Portugal, Romania, Russia, Slovakia,
-    Slovenia, Spain,
+    Malta, Monaco, Netherlands, Norway, Poland, Portugal, Romania, Russia,
+    Slovakia, Slovenia, Spain,
     # Catalonia,  # TODO: Add it to registry
     Sweden, UnitedKingdom,
     UnitedKingdomNorthernIreland,
@@ -69,6 +69,7 @@ class RegistryEurope(TestCase):
         self.assertIn(Lithuania, classes)
         self.assertIn(Luxembourg, classes)
         self.assertIn(Malta, classes)
+        self.assertIn(Monaco, classes)
         self.assertIn(Netherlands, classes)
         self.assertIn(Norway, classes)
         self.assertIn(Poland, classes)


### PR DESCRIPTION
refs #

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Docstrings for the Calendar class and specific methods.
- [x] Use the ``workalendar.registry_tools.iso_register`` decorator to register your new calendar using ISO codes (optional).
- [x] Calendar country / label added to the README.rst file.
- [x] Changelog amended with a mention like: "Added ``<country>`` by ``@pseudo`` (#)". **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*

