### PR TITLE
Fix PRODID pattern for iCal exports: using current workalendar version

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 ### New feature
 
 - Added iCal export feature, initiated by @joooeey (#197).
+- Fix PRODID pattern for iCal exports: `"PRODID:-//workalendar//ical {__version__}//EN"`, using current workalendar version (#543).
 
 ## v10.4.0 (2020-08-28)
 

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -16,6 +16,7 @@ from .exceptions import (
     UnsupportedDateType, CalendarError,
     ICalExportRangeError, ICalExportTargetPathError
 )
+from . import __version__
 
 MON, TUE, WED, THU, FRI, SAT, SUN = range(7)
 
@@ -886,7 +887,7 @@ class CoreCalendar:
         ics = [
             'BEGIN:VCALENDAR',
             'VERSION:2.0',  # current RFC5545 version
-            'PRODID:-//workalendar//ical 9.0.0//EN'
+            'PRODID:-//workalendar//ical {}//EN'.format(__version__)
         ]
         common_timestamp = datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
         dtstamp = 'DTSTAMP;VALUE=DATE-TIME:%s' % common_timestamp

--- a/workalendar/tests/__init__.py
+++ b/workalendar/tests/__init__.py
@@ -8,6 +8,7 @@ from unittest import TestCase
 from freezegun import freeze_time
 
 from ..core import Calendar
+from .. import __version__
 
 
 class CoreCalendarTest(TestCase):
@@ -70,8 +71,9 @@ class GenericCalendarTest(CoreCalendarTest):
             # check header
             assert ics_file.readline() == 'BEGIN:VCALENDAR\n'
             assert ics_file.readline() == 'VERSION:2.0\n'
-            assert ics_file.readline().startswith(
-                'PRODID:-//workalendar//ical ')
+            prod_id_line = ics_file.readline()
+            assert prod_id_line == (
+                'PRODID:-//workalendar//ical {}//EN\n'.format(__version__))
             # check new year
             assert ics_file.readline() == 'BEGIN:VEVENT\n'
             first_event_name = holidays[0][1]


### PR DESCRIPTION
closes #543

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
