### PR TITLE
Improve coverage of Israel calendar

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Improve coverage of South Africa calendar (#546).
 - Improve coverage of Brazil calendar (#546).
 - Improve coverage of Canada (Nunavut) calendar (#546).
+- Improve coverage of Israel calendar (#546).
 
 ## v11.0.0 (2020-09-04)
 

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -681,6 +681,29 @@ class IsraelTest(GenericCalendarTest):
         }
         self.assertEqual(calculated_holidays, known_holidays)
 
+    def test_holidays_2021(self):
+        calculated_holidays = self.cal.holidays_set(2021)
+        known_holidays = {
+            date(2021, 9, 6),  # Rosh Hashana Eve
+            date(2021, 9, 7),  # Rosh Hashana A
+            date(2021, 9, 8),  # Rosh Hashana B
+            date(2021, 9, 15),  # Kippur Eve
+            date(2021, 9, 16),  # Kippur
+            date(2021, 9, 20),  # Sukot A Eve
+            date(2021, 9, 21),  # Sukot A
+            date(2021, 9, 27),  # Sukot B Eve
+            date(2021, 9, 28),  # Sukot B
+            date(2021, 3, 27),  # Pesach A Eve
+            date(2021, 3, 28),  # Pesach A
+            date(2021, 4, 2),  # Pesach B Eve
+            date(2021, 4, 3),  # Pesach B
+            date(2021, 4, 14),  # Independence Day Eve
+            date(2021, 4, 15),  # Independence Day
+            date(2021, 5, 16),  # Shavuot Eve
+            date(2021, 5, 17),  # Shavuot
+        }
+        self.assertEqual(calculated_holidays, known_holidays)
+
     def test_is_holiday_performance(self):
         random_date = date(2019, 10, 9)
         japan_cal = Japan()


### PR DESCRIPTION
refs #546

We had to include the year 2021, because it offered the case that was missing in the `get_hebrew_independence_day` method.

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
