### PR TITLE
Improve coverage of Singapore calendar

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Improve coverage of Singapore calendar (#546).
 
 ## v11.0.1 (2020-09-11)
 

--- a/workalendar/asia/singapore.py
+++ b/workalendar/asia/singapore.py
@@ -64,6 +64,10 @@ class Singapore(WesternMixin, IslamicMixin, ChineseNewYearCalendar):
         """
         Singapore variable days
         """
+        if year not in self.DEEPAVALI:
+            msg = 'Missing date for Singapore Deepavali for year: %s' % year
+            raise KeyError(msg)
+
         days = super().get_variable_days(year)
 
         # Vesak Day
@@ -72,9 +76,5 @@ class Singapore(WesternMixin, IslamicMixin, ChineseNewYearCalendar):
         )
 
         # Add in Deepavali (hardcoded dates, so no need to shift)
-        deepavali = self.DEEPAVALI.get(year)
-        if not deepavali:
-            msg = 'Missing date for Singapore Deepavali for year: %s' % year
-            raise KeyError(msg)
-        days.append((deepavali, 'Deepavali'))
+        days.append((self.DEEPAVALI.get(year), 'Deepavali'))
         return days

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -527,6 +527,15 @@ class SingaporeTest(GenericCalendarTest):
         current_year = date.today().year
         self.assertIn(current_year, self.cal.DEEPAVALI)
 
+    def test_deepavali_missing_year(self):
+        with self.assertRaises(KeyError) as context:
+            self.cal.holidays_set(1999)
+        self.assertEqual(
+            # Equivalent of the error msg
+            context.exception.args[0],
+            'Missing date for Singapore Deepavali for year: 1999',
+        )
+
 
 class SouthKoreaTest(GenericCalendarTest):
 


### PR DESCRIPTION
Small refactor to trigger the KeyError a bit earlier.

refs #546

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes.
