### PR TITLE
Deprecate Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache: pip
 install: pip install tox tox-travis
 script: tox -v
 python:
-- 3.5
 - 3.6
 - 3.7
 - 3.8

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+- **Deprecation:** Dropped support for Python 3.5 (#330).
 - Improve coverage of Singapore calendar (#546).
 
 ## v11.0.1 (2020-09-11)

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ For a more complete documentation and advanced usage, go to
 External dependencies
 =====================
 
-Workalendar has been tested on Python 3.5, 3.6, 3.7, 3.8.
+Workalendar has been tested on Python 3.6, 3.7, 3.8.
 
 If you're using wheels, you should be fine without having to install extra system packages. As of ``v7.0.0``, we have dropped ``ephem`` as a dependency for computing astronomical ephemeris in favor of ``skyfield``. So if you had any trouble because of this new dependency, during the installation or at runtime, `do not hesitate to file an issue <https://github.com/peopledoc/workalendar/issues/>`_.
 

--- a/contributing.md
+++ b/contributing.md
@@ -59,7 +59,7 @@ pip install -e ./
 When you provide a patch for workalendar, whether it would be a new calendar or a fix to an existing one, or else, you will have to make sure that your contribution follows these basic requirements:
 
 * Your code should pass the `flake8` test ; that is to say that it follows the [PEP8](https://www.python.org/dev/peps/pep-0008/) guidelines. You can check using the `tox -e flake8` command. If you can't, our travis jobs will do it, and you'll be able to know where are your mistakes, if any.
-* Your code should be compatible with our supported Python version. Currently: Python 3.5, 3.6, 3.7 and 3.8. Again, the Travis CI will check your code against all those versions so you won't have to.
+* Your code should be compatible with our supported Python version. Currently: Python 3.6, 3.7 and 3.8. Again, the Travis CI will check your code against all those versions so you won't have to.
 
 #### Test-driven start
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ params = dict(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,flake8,py37,py38
+envlist = flake8,py36,py37,py38
 
 [testenv]
 deps =

--- a/workalendar/astronomy.py
+++ b/workalendar/astronomy.py
@@ -1,7 +1,7 @@
 """
 Astronomical functions
 """
-from math import pi, radians
+from math import pi, radians, tau
 import pytz
 from skyfield.api import Loader
 from skyfield import almanac
@@ -15,9 +15,6 @@ hour = 1. / 24.
 minute = hour / 60.
 second = minute / 60.
 newton_precision = second / 10.
-
-# ``math.tau`` appears only in Python 3.6+
-tau = 2 * pi
 
 
 def calculate_equinoxes(year, timezone='UTC'):


### PR DESCRIPTION
refs #330


- [x] No regression in tests (imported `math.tau`).
- [x] Contributing + README doc changed,
- [x] Removed py35 tests.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
