### PR TITLE
Require Python version 3.6+ as of the next release.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-- **Deprecation:** Dropped support for Python 3.5 (#330).
+- **Deprecation:** Dropped support for Python 3.5. As of this version, workalendar now requires Python 3.6+ (#330).
 - Improve coverage of Singapore calendar (#546).
 
 ## v11.0.1 (2020-09-11)

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,8 @@ External dependencies
 
 Workalendar has been tested on Python 3.6, 3.7, 3.8.
 
+**Incompatibility:** Workalendar will require you to use Python 3.6+.
+
 If you're using wheels, you should be fine without having to install extra system packages. As of ``v7.0.0``, we have dropped ``ephem`` as a dependency for computing astronomical ephemeris in favor of ``skyfield``. So if you had any trouble because of this new dependency, during the installation or at runtime, `do not hesitate to file an issue <https://github.com/peopledoc/workalendar/issues/>`_.
 
 Tests

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ params = dict(
     author_email='bruno.bord@people-doc.com',
     url='https://github.com/peopledoc/workalendar',
     license='MIT License',
+    python_requires='>=3.6',
     include_package_data=True,
     install_requires=REQUIREMENTS,
     zip_safe=False,


### PR DESCRIPTION
refs #330

- [x] Tests are ok
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*

On top of that, I've tried the following cases:

* run the 3.5 tests with the `python_requires` => Failed to install
* run the 3.5 tests without the `python_requires` => Failed to test, because of the `math.tau` change (only available in Python 3.6)

This will make users unable to install workalendar 12.x+ if they're still running Python 3.5 in their environment.