### PR TITLE
Add a pyupgrade test job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ matrix:
   include:
   - python: 3.8
     env: TOXENV=flake8
+  - python: 3.8
+    env: TOXENV=pyupgrade

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 - Improve coverage for the Romania calendar - Liberation day (#546).
 - Improve coverage for the New Zealand calendar (#546).
 - Added a tox entrypoint to ensure code is Python 3.6+, using ``pyupgrade`` (#566).
+- Added the pyupgrade tox job to the test suite, amended contributing documentation (#566).
 
 ## v12.0.0 (2020-10-02)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 - Improve coverage for the Netherlands calendar - Queen's Day (#546).
 - Improve coverage for the Romania calendar - Liberation day (#546).
 - Improve coverage for the New Zealand calendar (#546).
+- Added a tox entrypoint to ensure code is Python 3.6+, using ``pyupgrade`` (#566).
 
 ## v12.0.0 (2020-10-02)
 

--- a/contributing.md
+++ b/contributing.md
@@ -60,6 +60,7 @@ When you provide a patch for workalendar, whether it would be a new calendar or 
 
 * Your code should pass the `flake8` test ; that is to say that it follows the [PEP8](https://www.python.org/dev/peps/pep-0008/) guidelines. You can check using the `tox -e flake8` command. If you can't, our travis jobs will do it, and you'll be able to know where are your mistakes, if any.
 * Your code should be compatible with our supported Python version. Currently: Python 3.6, 3.7 and 3.8. Again, the Travis CI will check your code against all those versions so you won't have to.
+* If you encounter a failure in the `pyupgrade` tox job, you can fix it by running the followinf command: `tox -r pyupgrade`. It'll modify your code so it will pass this test. **Warning:** sometimes, this change can break the `flake8` standards, so you'll have to make sure that both linters will pass.
 
 #### Test-driven start
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import io
 from os.path import join, dirname, abspath
 from setuptools import setup, find_packages
@@ -12,7 +11,7 @@ def read_relative_file(filename):
     Its path is supposed relative to this module.
     """
     path = join(dirname(abspath(__file__)), filename)
-    with io.open(path, encoding='utf-8') as f:
+    with open(path, encoding='utf-8') as f:
         return f.read()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,5 +17,11 @@ commands =
 [testenv:flake8]
 deps =
     flake8
-
 commands = flake8 workalendar
+
+[testenv:pyupgrade]
+deps =
+    pyupgrade-directories
+commands_pre =
+skip_install = true
+commands = pyup_dirs --py36-plus --recursive . 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py36,py37,py38
+envlist = pyupgrade,flake8,py36,py37,py38
 
 [testenv]
 deps =
@@ -17,6 +17,8 @@ commands =
 [testenv:flake8]
 deps =
     flake8
+commands_pre =
+skip_install = true
 commands = flake8 workalendar
 
 [testenv:pyupgrade]
@@ -24,4 +26,4 @@ deps =
     pyupgrade-directories
 commands_pre =
 skip_install = true
-commands = pyup_dirs --py36-plus --recursive . 
+commands = pyup_dirs --py36-plus --recursive .

--- a/workalendar/america/barbados.py
+++ b/workalendar/america/barbados.py
@@ -50,7 +50,8 @@ class Barbados(WesternCalendar):
         days_to_shift = copy(days)
         for day, label in days_to_shift:
             if day.weekday() == SUN:
-                days.append(
-                    (day + timedelta(days=1), "%s %s" % (label, "(shifted)"))
-                )
+                days.append((
+                    day + timedelta(days=1),
+                    "{} {}".format(label, "(shifted)")
+                ))
         return days

--- a/workalendar/america/canada.py
+++ b/workalendar/america/canada.py
@@ -269,7 +269,7 @@ class PrinceEdwardIsland(LateFamilyDayMixin, RemembranceDayShiftMixin, Canada):
 
     def get_variable_days(self, year):
         days = super().get_variable_days(year)
-        days.append((self.get_family_day(year, "Islander Day")))
+        days.append(self.get_family_day(year, "Islander Day"))
         days.extend(self.get_remembrance_day(year))
         return days
 

--- a/workalendar/asia/china.py
+++ b/workalendar/asia/china.py
@@ -82,7 +82,7 @@ class China(ChineseNewYearCalendar):
             )
         )
         if year not in holidays.keys():
-            msg = "Need configure {} for China.".format(year)
+            msg = f"Need configure {year} for China."
             raise CalendarError(msg)
         return super().get_calendar_holidays(year)
 

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -148,7 +148,7 @@ class ChristianMixin:
         """
         christmas = date(year, 12, 25)
         boxing_day = date(year, 12, 26)
-        boxing_day_label = "{} Shift".format(self.boxing_day_label)
+        boxing_day_label = f"{self.boxing_day_label} Shift"
         results = []
         if christmas.weekday() in self.get_weekend_days():
             shift = self.find_following_working_day(christmas)
@@ -532,7 +532,7 @@ class CoreCalendar:
 
     def holidays_set(self, year=None):
         "Return a quick date index (set)"
-        return set([day for day, label in self.holidays(year)])
+        return {day for day, label in self.holidays(year)}
 
     def get_weekend_days(self):
         """Return a list (or a tuple) of weekdays that are *not* working days.
@@ -885,7 +885,7 @@ class CoreCalendar:
         ics = [
             'BEGIN:VCALENDAR',
             'VERSION:2.0',  # current RFC5545 version
-            'PRODID:-//workalendar//ical {}//EN'.format(__version__)
+            f'PRODID:-//workalendar//ical {__version__}//EN'
         ]
         common_timestamp = datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
         dtstamp = 'DTSTAMP;VALUE=DATE-TIME:%s' % common_timestamp
@@ -897,7 +897,7 @@ class CoreCalendar:
                 'SUMMARY:%s' % name,
                 'DTSTART;VALUE=DATE:%s' % date_.strftime('%Y%m%d'),
                 dtstamp,
-                'UID:%s%s@peopledoc.github.io/workalendar' % (date_, name),
+                f'UID:{date_}{name}@peopledoc.github.io/workalendar',
                 'END:VEVENT',
             ])
 

--- a/workalendar/registry.py
+++ b/workalendar/registry.py
@@ -32,7 +32,7 @@ class IsoRegistry:
         self.region_registry = dict()
         if load_standard_modules:
             for module_name in self.STANDARD_MODULES:
-                module = 'workalendar.{}'.format(module_name)
+                module = f'workalendar.{module_name}'
                 all_classes = getattr(import_module(module), '__all__')
                 self.load_module_from_items(module, all_classes)
 
@@ -42,7 +42,7 @@ class IsoRegistry:
         """
         if not issubclass(cls, Calendar):
             raise ISORegistryError(
-                "Class `{}` is not a Calendar class".format(cls)
+                f"Class `{cls}` is not a Calendar class"
             )
         self.region_registry[iso_code] = cls
 
@@ -86,7 +86,7 @@ class IsoRegistry:
         """
         items = dict()
         for key, value in self.region_registry.items():
-            if key.startswith("{}-".format(iso_code)):
+            if key.startswith(f"{iso_code}-"):
                 items[key] = value
         return items
 

--- a/workalendar/tests/__init__.py
+++ b/workalendar/tests/__init__.py
@@ -73,7 +73,7 @@ class GenericCalendarTest(CoreCalendarTest):
             assert ics_file.readline() == 'VERSION:2.0\n'
             prod_id_line = ics_file.readline()
             assert prod_id_line == (
-                'PRODID:-//workalendar//ical {}//EN\n'.format(__version__))
+                f'PRODID:-//workalendar//ical {__version__}//EN\n')
             # check new year
             assert ics_file.readline() == 'BEGIN:VEVENT\n'
             first_event_name = holidays[0][1]

--- a/workalendar/tests/test_ical_export.py
+++ b/workalendar/tests/test_ical_export.py
@@ -129,7 +129,7 @@ class ICalExportTargetPath(CoreCalendarTest):
 
     def test_known_extensions(self):
         for ext in ('ical', 'ics', 'ifb', 'icalendar'):
-            filename = "a.{}".format(ext)
+            filename = f"a.{ext}"
             self.assertEqual(
                 self.cal._get_ical_target_path(filename),
                 filename

--- a/workalendar/tests/test_usa.py
+++ b/workalendar/tests/test_usa.py
@@ -473,7 +473,7 @@ class CaliforniaTest(NoColumbus, UnitedStatesTest):
         days = [item[0] for item in holidays]
         assert days
         for day in days:
-            assert days.count(day) == 1, "{} is duplicated".format(day)
+            assert days.count(day) == 1, f"{day} is duplicated"
 
 
 class CaliforniaEducationTest(CaliforniaTest):

--- a/workalendar/usa/core.py
+++ b/workalendar/usa/core.py
@@ -257,7 +257,7 @@ class UnitedStates(WesternCalendar):
         """
         if ((year - 1) % 4) != 0:
             raise ValueError(
-                "The year {} is not an Inauguration Year".format(year))
+                f"The year {year} is not an Inauguration Year")
         inauguration_day = date(year, 1, 20)
         if inauguration_day.weekday() == SUN:
             inauguration_day = date(year, 1, 21)


### PR DESCRIPTION
refs #566

* [x] Use pyupgrade to apply patches to the source code so they'll be py36+ compatible and move out old Python 2 syntax bits
* [x] Add a pyupgrade travis test job to enforce those rules
* [x] Edit documentation (CONTRIBUTING) to explain why and how the job can fail and how to eventually fix it.