### PR TITLE
Fix COVID-19 2020 non-working days: these are not shifted

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@
 - Fix Russia calendar: non-working days are shifted to the next MON when they happen on the week-end (#589).
 - Fix Russia New year holidays. It has become a week off since 2005 (related to #578).
 - Added a `daterange` function in `workalendar.core` module to iterate between two dates.
-- Added Russia COVID-19 non-working days for the year 2020 (#578).
+- Added Russia COVID-19 non-working days for the year 2020 ; these days are not shifted to next MON (#578).
 
 ## v13.0.0 (2020-11-13)
 

--- a/workalendar/europe/russia.py
+++ b/workalendar/europe/russia.py
@@ -20,6 +20,9 @@ class Russia(OrthodoxCalendar):
         (11, 4, "Day of Unity"),
     )
 
+    covid19_2020_start = date(2020, 3, 28)
+    covid19_2020_end = date(2020, 4, 30)
+
     def get_fixed_holidays(self, year):
         days = super().get_fixed_holidays(year)
 
@@ -34,7 +37,8 @@ class Russia(OrthodoxCalendar):
 
         if year == 2020:
             index = 1
-            for day in daterange(date(year, 3, 28), date(year, 4, 30)):
+            for day in daterange(self.covid19_2020_start,
+                                 self.covid19_2020_end):
                 days.append(
                     (day, f"Non-Working Day (COVID-19) #{index}")
                 )
@@ -46,6 +50,9 @@ class Russia(OrthodoxCalendar):
         shifts = []
         for day, label in holidays:
             if day.month == 1 and day.day in range(1, 9):
+                continue
+            # Add an exception for 2020 non-working days due to COVID-19
+            if self.covid19_2020_start <= day <= self.covid19_2020_end:
                 continue
             if day.weekday() in self.get_weekend_days():
                 shifts.append((

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -1454,6 +1454,15 @@ class RussiaTest(GenericCalendarTest):
         for day in daterange(start, end):
             self.assertNotIn(day, holidays)
 
+    def test_covid19_2020_label(self):
+        # no "shift" for those days, all of them were non-working days
+        holidays = self.cal.holidays(2020)
+        start = date(2020, 3, 28)
+        end = date(2020, 4, 30)
+        for day, label in holidays:
+            if start <= day <= end:
+                self.assertNotIn("shift", label)
+
     def test_new_year_holidays_2004(self):
         # At that time, only Jan 1st/2nd were holidays.
         holidays = self.cal.holidays_set(2004)


### PR DESCRIPTION
refs #578

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
