### PR TITLE
Update China's public holidays for 2021.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 - Fix Russia New year holidays. It has become a week off since 2005 (related to #578).
 - Added a `daterange` function in `workalendar.core` module to iterate between two dates.
 - Added Russia COVID-19 non-working days for the year 2020 ; these days are not shifted to next MON (#578).
+- Update China's public holidays for 2021.
 
 ## v13.0.0 (2020-11-13)
 

--- a/workalendar/asia/china.py
+++ b/workalendar/asia/china.py
@@ -28,6 +28,13 @@ holidays = {
             'Dragon Boat Festival': [(6, 25), (6, 26), (6, 27)],
             'National Day': [(10, 8)]
         },
+    2021:
+        {
+            'Ching Ming Festival': [(4, 3), (4, 4), (4, 5)],
+            'Labour Day Holiday': [(5, 1), (5, 2), (5, 3), (5, 4), (5, 5)],
+            'Dragon Boat Festival': [(6, 12), (6, 13), (6, 14)],
+            'Mid-Autumn Festival': [(9, 19), (9, 20), (9, 21)]
+        },
 }
 
 workdays = {
@@ -51,6 +58,13 @@ workdays = {
             'Labour Day Holiday Shift': [(4, 26), (5, 9)],
             'Dragon Boat Festival Shift': [(6, 28)],
             'National Day Shift': [(9, 27), (10, 10)]
+        },
+    2021:
+        {
+            'Spring Festival Shift': [(2, 7), (2, 20)],
+            'Labour Day Holiday Shift': [(4, 25), (5, 8)],
+            'Mid-Autumn Festival Shift': [(9, 18)],
+            'National Day Shift': [(9, 26), (10, 9)]
         },
 }
 

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -63,6 +63,30 @@ class ChinaTest(GenericCalendarTest):
         self.assertNotIn(date(2020, 9, 27), holidays)  # National Day Shift
         self.assertNotIn(date(2020, 10, 10), holidays)  # National Day Shift
 
+    def test_year_2021(self):
+        holidays = self.cal.holidays_set(2021)
+        self.assertIn(date(2021, 1, 1), holidays)  # New Year
+        self.assertIn(date(2021, 2, 11), holidays)  # Spring Festival
+        self.assertIn(date(2021, 2, 17), holidays)  # Spring Festival
+        self.assertIn(date(2021, 4, 3), holidays)  # Ching Ming Festival
+        self.assertIn(date(2021, 4, 5), holidays)  # Ching Ming Festival
+        self.assertIn(date(2021, 5, 1), holidays)  # Labour Day Holiday
+        self.assertIn(date(2021, 5, 5), holidays)  # Labour Day Holiday
+        self.assertIn(date(2021, 6, 12), holidays)  # Dragon Boat Festival
+        self.assertIn(date(2021, 6, 14), holidays)  # Dragon Boat Festival
+        self.assertIn(date(2021, 9, 19), holidays)  # Mid-Autumn Festival
+        self.assertIn(date(2021, 9, 21), holidays)  # Mid-Autumn Festival
+        self.assertIn(date(2021, 10, 1), holidays)  # National Day
+        self.assertIn(date(2021, 10, 7), holidays)  # National Day
+
+        self.assertNotIn(date(2021, 2, 7), holidays)  # Spring Festival Shift
+        self.assertNotIn(date(2021, 2, 20), holidays)  # Spring Festival Shift
+        self.assertNotIn(date(2021, 4, 25), holidays)  # Labour Day Shift
+        self.assertNotIn(date(2021, 5, 8), holidays)  # Labour Day Shift
+        self.assertNotIn(date(2021, 9, 18), holidays)  # Mid-Autumn Shift
+        self.assertNotIn(date(2021, 9, 26), holidays)  # National Day Shift
+        self.assertNotIn(date(2021, 10, 9), holidays)  # National Day Shift
+
     def test_missing_holiday_year(self):
         save_2018 = china_holidays[2018]
         del china_holidays[2018]
@@ -75,7 +99,7 @@ class ChinaTest(GenericCalendarTest):
         with patch('warnings.warn') as patched:
             self.cal.get_calendar_holidays(year)
         patched.assert_called_with(
-            'Support years 2018-2020 currently, need update every year.'
+            'Support years 2018-2021 currently, need update every year.'
         )
 
     def test_is_working_day(self):


### PR DESCRIPTION
Update China's public holidays for 2021.

refs #
http://www.gov.cn/zhengce/content/2020-11/25/content_5564127.htm
