### PR TITLE
Fixed Russia Christmas day & several other Orthodox calendars

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 - Fix Russia New year holidays. It has become a week off since 2005 (related to #578).
 - Added a `daterange` function in `workalendar.core` module to iterate between two dates.
 - Added Russia COVID-19 non-working days for the year 2020 ; these days are not shifted to next MON (#578).
+- Fixed Russia Christmas day ; December 25th is not a public holiday. Fixed several other Orthodox calendars (#530).
 
 ## v13.0.0 (2020-11-13)
 

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -85,6 +85,7 @@ class ChristianMixin:
     include_immaculate_conception = False
     immaculate_conception_label = "Immaculate Conception"
     include_christmas = True
+    christmas_day_label = "Christmas Day"
     include_christmas_eve = False
     include_ascension = False
     include_assumption = False
@@ -212,7 +213,7 @@ class ChristianMixin:
         if self.include_immaculate_conception:
             days.append((date(year, 12, 8), self.immaculate_conception_label))
         if self.include_christmas:
-            days.append((date(year, 12, 25), "Christmas Day"))
+            days.append((date(year, 12, 25), self.christmas_day_label))
         if self.include_christmas_eve:
             days.append((date(year, 12, 24), "Christmas Eve"))
         if self.include_boxing_day:
@@ -243,6 +244,18 @@ class WesternMixin(ChristianMixin):
 class OrthodoxMixin(ChristianMixin):
     EASTER_METHOD = easter.EASTER_ORTHODOX
     WEEKEND_DAYS = (SAT, SUN)
+
+    include_orthodox_christmas = True
+    # This label should be de-duplicated if needed
+    orthodox_christmas_day_label = "Christmas"
+
+    def get_fixed_holidays(self, year):
+        days = super().get_fixed_holidays(year)
+        if self.include_orthodox_christmas:
+            days.append(
+                (date(year, 1, 7), self.orthodox_christmas_day_label)
+            )
+        return days
 
 
 class LunarMixin:

--- a/workalendar/europe/belarus.py
+++ b/workalendar/europe/belarus.py
@@ -11,16 +11,16 @@ class Belarus(OrthodoxCalendar):
     include_labour_day = True
 
     # Christian holidays
-    include_christmas = False
+    include_christmas = True
+    christmas_day_label = "Christmas Day (Catholic)"
+    orthodox_christmas_day_label = "Christmas (Orthodox)"
 
     FIXED_HOLIDAYS = OrthodoxCalendar.FIXED_HOLIDAYS + (
         (1, 2, "Day After New Year"),
-        (1, 7, "Christmas (Orthodox)"),
         (3, 8, "International Women's Day"),
         (5, 9, "Victory Day"),
         (7, 3, "Republic Day"),
         (11, 7, "October Revolution Day"),
-        (12, 25, "Christmas (Catholic)"),
     )
     # Radonitsa
     # https://en.wikipedia.org/wiki/Radonitsa

--- a/workalendar/europe/greece.py
+++ b/workalendar/europe/greece.py
@@ -26,3 +26,5 @@ class Greece(OrthodoxCalendar):
     include_assumption = True
     include_boxing_day = True
     boxing_day_label = "Glorifying Mother of God"
+    # No Orthodox Christmas
+    include_orthodox_christmas = False

--- a/workalendar/europe/romania.py
+++ b/workalendar/europe/romania.py
@@ -28,6 +28,8 @@ class Romania(OrthodoxCalendar):
     include_christmas = True
     include_boxing_day = True
     boxing_day_label = 'Christmas Day'
+    # No Orthodox Christmas
+    include_orthodox_christmas = False
 
     def get_childrens_day(self, year):
         """returns a possibly empty list of (date, holiday_name) tuples"""

--- a/workalendar/europe/russia.py
+++ b/workalendar/europe/russia.py
@@ -12,13 +12,15 @@ class Russia(OrthodoxCalendar):
 
     FIXED_HOLIDAYS = OrthodoxCalendar.FIXED_HOLIDAYS + (
         (1, 2, "Day After New Year"),
-        (1, 7, "Christmas"),
         (2, 23, "Defendence of the Fatherland"),
         (3, 8, "International Women's Day"),
         (5, 9, "Victory Day"),
         (6, 12, "National Day"),
         (11, 4, "Day of Unity"),
     )
+
+    # Christian holidays
+    include_christmas = False
 
     covid19_2020_start = date(2020, 3, 28)
     covid19_2020_end = date(2020, 4, 30)

--- a/workalendar/europe/serbia.py
+++ b/workalendar/europe/serbia.py
@@ -8,7 +8,6 @@ class Serbia(OrthodoxCalendar):
 
     FIXED_HOLIDAYS = OrthodoxCalendar.FIXED_HOLIDAYS + (
         (1, 2, "Day After New Year"),
-        (1, 7, "Christmas"),
         (2, 15, "Statehood Day"),
         (2, 16, "Statehood Day"),
         (5, 2, "Labour Day Holiday"),

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -605,6 +605,11 @@ class GreeceTest(GenericCalendarTest):
         self.assertIn(date(2020, 12, 25), holidays)  # XMas
         self.assertIn(date(2020, 12, 26), holidays)  # Glorifying mother of God
 
+    def test_no_orthodox_christmas(self):
+        # This calendar is an Orthodox calendar, but there's no Jan XMas
+        holidays = self.cal.holidays_set(2020)
+        self.assertNotIn(date(2020, 1, 7), holidays)
+
 
 class HungaryTest(GenericCalendarTest):
     cal_class = Hungary
@@ -1395,6 +1400,11 @@ class RomaniaTest(GenericCalendarTest):
         holidays = self.cal.holidays_set(1991)
         self.assertNotIn(liberation_day_1991, holidays)
 
+    def test_no_orthodox_christmas(self):
+        # This calendar is an Orthodox calendar, but there's no Jan XMas
+        holidays = self.cal.holidays_set(2020)
+        self.assertNotIn(date(2020, 1, 7), holidays)
+
 
 class RussiaTest(GenericCalendarTest):
     cal_class = Russia
@@ -1485,6 +1495,11 @@ class RussiaTest(GenericCalendarTest):
         self.assertIn(date(2005, 1, 6), holidays)  # Holiday since 2005
         self.assertIn(date(2005, 1, 7), holidays)  # XMas
         self.assertIn(date(2005, 1, 8), holidays)  # Part of the holiday week
+
+    def test_no_december_christmas(self):
+        # This calendar is an Orthodox calendar & it doesn't include Dec 25th
+        holidays = self.cal.holidays_set(2020)
+        self.assertNotIn(date(2020, 12, 25), holidays)
 
 
 class UkraineTest(GenericCalendarTest):
@@ -1808,6 +1823,11 @@ class SerbiaTest(GenericCalendarTest):
         self.assertIn(date(2017, 5, 1), holidays)
         self.assertIn(date(2017, 5, 2), holidays)
         self.assertIn(date(2017, 11, 11), holidays)
+
+    def test_no_december_christmas(self):
+        # This calendar is an Orthodox calendar & it doesn't include Dec 25th
+        holidays = self.cal.holidays_set(2020)
+        self.assertNotIn(date(2020, 12, 25), holidays)
 
 
 class SloveniaTest(GenericCalendarTest):


### PR DESCRIPTION
closes #530

* Set Orthodox Christmas as a parametrizable holiday.
* in Russia, December 25th is not a public holiday.
* Fixed several other Orthodox calendars


- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
