### PR TITLE
Use f-strings to format strings

### DIFF
--- a/docs/iso-registry.md
+++ b/docs/iso-registry.md
@@ -10,7 +10,7 @@ As of version 3.0 (August/September 2018), we have introduced a global calendar 
 >>> from workalendar.registry import registry
 >>> calendars = registry.get_calendars()  # This returns a dictionary
 >>> for code, calendar_class in calendars.items():
-...     print("`{}` is code for '{}'".format(code, calendar_class.name))
+...     print(f"`{code}` is code for {calendar_class.name!r}")
 `AT` is code for 'Austria'
 `BE` is code for 'Belgium'
 `BG` is code for 'Bulgaria'

--- a/workalendar/africa/kenya.py
+++ b/workalendar/africa/kenya.py
@@ -59,7 +59,7 @@ class Kenya(IslamoWesternCalendar):
                     label != self.day_of_sacrifice_label):
                 yield (
                     holiday + timedelta(days=1),
-                    label + ' Shift'
+                    f'{label} Shift'
                 )
 
     def get_calendar_holidays(self, year):

--- a/workalendar/africa/south_africa.py
+++ b/workalendar/africa/south_africa.py
@@ -122,7 +122,7 @@ class SouthAfrica(WesternCalendar):
             if holiday.weekday() == SUN:
                 days.append((
                     holiday + timedelta(days=1),
-                    "%s substitute" % label
+                    f"{label} substitute"
                 ))
 
         # Other one-offs. Don't shift these

--- a/workalendar/america/argentina.py
+++ b/workalendar/america/argentina.py
@@ -46,9 +46,10 @@ class Argentina(WesternCalendar):
         else:
             general_guemes_day
 
-        return (general_guemes_day,
-                "Día Paso a la Inmortalidad del " +
-                "General Martín Miguel de Güemes")
+        return (
+            general_guemes_day,
+            "Día Paso a la Inmortalidad del General Martín Miguel de Güemes"
+        )
 
     def get_general_martin_day(self, year):
         """
@@ -60,9 +61,10 @@ class Argentina(WesternCalendar):
             year, 8, MON, 3
         )
 
-        return (general_martin_day,
-                "Día Paso a la Inmortalidad del " +
-                "Gral. José de San Martín")
+        return (
+            general_martin_day,
+            "Día Paso a la Inmortalidad del Gral. José de San Martín"
+        )
 
     def get_soberania_day(self, year):
         """

--- a/workalendar/america/barbados.py
+++ b/workalendar/america/barbados.py
@@ -50,8 +50,5 @@ class Barbados(WesternCalendar):
         days_to_shift = copy(days)
         for day, label in days_to_shift:
             if day.weekday() == SUN:
-                days.append((
-                    day + timedelta(days=1),
-                    "{} {}".format(label, "(shifted)")
-                ))
+                days.append((day + timedelta(days=1), f"{label} (shifted)"))
         return days

--- a/workalendar/america/mexico.py
+++ b/workalendar/america/mexico.py
@@ -35,9 +35,9 @@ class Mexico(WesternCalendar):
         # If it's on a Saturday, the Friday is off
         for day, label in days:
             if day.weekday() == SAT:
-                days.append((day - timedelta(days=1), "%s substitute" % label))
+                days.append((day - timedelta(days=1), f"{label} substitute"))
             elif day.weekday() == SUN:
-                days.append((day + timedelta(days=1), "%s substitute" % label))
+                days.append((day + timedelta(days=1), f"{label} substitute"))
         # Extra: if new year's day is a saturday, the friday before is off
         next_new_year = date(year + 1, 1, 1)
         if next_new_year.weekday():

--- a/workalendar/asia/china.py
+++ b/workalendar/asia/china.py
@@ -90,10 +90,8 @@ class China(ChineseNewYearCalendar):
     def get_calendar_holidays(self, year):
         year_min, year_max = min(holidays.keys()), max(holidays.keys())
         warnings.warn(
-            "Support years {}-{} currently, need update every year.".format(
-                year_min,
-                year_max,
-            )
+            f"Support years {year_min}-{year_max} currently, "
+            f"need update every year."
         )
         if year not in holidays.keys():
             msg = f"Need configure {year} for China."

--- a/workalendar/asia/malaysia.py
+++ b/workalendar/asia/malaysia.py
@@ -83,13 +83,13 @@ class Malaysia(IslamicMixin, ChineseNewYearCalendar):
         # Add in Deepavali and Thaipusam (hardcoded dates, so no need to shift)
         msia_deepavali = self.MSIA_DEEPAVALI.get(year)
         if not msia_deepavali:
-            mdmsg = 'Missing date for Malaysia Deepavali for year: %s' % year
+            mdmsg = f'Missing date for Malaysia Deepavali for year: {year}'
             raise KeyError(mdmsg)
         days.append((msia_deepavali, 'Deepavali'))
 
         msia_thaipusam = self.MSIA_THAIPUSAM.get(year)
         if not msia_thaipusam:
-            mtmsg = 'Missing date for Malaysia Thaipusam for year: %s' % year
+            mtmsg = f'Missing date for Malaysia Thaipusam for year: {year}'
             raise KeyError(mtmsg)
         days.append((msia_thaipusam, 'Thaipusam'))
         return days

--- a/workalendar/asia/singapore.py
+++ b/workalendar/asia/singapore.py
@@ -65,7 +65,7 @@ class Singapore(WesternMixin, IslamicMixin, ChineseNewYearCalendar):
         Singapore variable days
         """
         if year not in self.DEEPAVALI:
-            msg = 'Missing date for Singapore Deepavali for year: %s' % year
+            msg = f'Missing date for Singapore Deepavali for year: {year}'
             raise KeyError(msg)
 
         days = super().get_variable_days(year)

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -40,7 +40,8 @@ def cleaned_date(day, keep_datetime=False):
     """
     if not isinstance(day, (date, datetime)):
         raise UnsupportedDateType(
-            "`{}` is of unsupported type ({})".format(day, type(day)))
+            f"`{day}` is of unsupported type ({type(day)})"
+        )
     if not keep_datetime:
         if hasattr(day, 'date') and callable(day.date):
             day = day.date()
@@ -367,7 +368,7 @@ class ChineseNewYearMixin(LunarMixin):
             if holiday.weekday() == SUN:
                 yield (
                     holiday + timedelta(days=1),
-                    label + ' shift'
+                    f'{label} shift'
                 )
 
     def get_calendar_holidays(self, year):
@@ -396,7 +397,8 @@ class CalverterMixin:
 
     def converted(self, year):
         conversion_method = getattr(
-            self.calverter, 'jd_to_%s' % self.conversion_method)
+            self.calverter, f'jd_to_{self.conversion_method}'
+        )
         current = date(year, 1, 1)
         days = []
         while current.year == year:
@@ -430,7 +432,7 @@ class CalverterMixin:
         days = super().get_variable_days(year)
         years = self.calverted_years(year)
         conversion_method = getattr(
-            self.calverter, '%s_to_jd' % self.conversion_method)
+            self.calverter, f'{self.conversion_method}_to_jd')
         for month, day, label in self.get_islamic_holidays():
             for y in years:
                 jd = conversion_method(y, month, day)
@@ -916,15 +918,14 @@ class CoreCalendar:
             'VERSION:2.0',  # current RFC5545 version
             f'PRODID:-//workalendar//ical {__version__}//EN'
         ]
-        common_timestamp = datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
-        dtstamp = 'DTSTAMP;VALUE=DATE-TIME:%s' % common_timestamp
+        dtstamp = f'DTSTAMP;VALUE=DATE-TIME:{datetime.utcnow():%Y%m%dT%H%M%SZ}'
 
         # add an event for each holiday
         for date_, name in holidays:
             ics.extend([
                 'BEGIN:VEVENT',
-                'SUMMARY:%s' % name,
-                'DTSTART;VALUE=DATE:%s' % date_.strftime('%Y%m%d'),
+                f'SUMMARY:{name}',
+                f'DTSTART;VALUE=DATE:{date_:%Y%m%d}',
                 dtstamp,
                 f'UID:{date_}{name}@peopledoc.github.io/workalendar',
                 'END:VEVENT',

--- a/workalendar/europe/netherlands.py
+++ b/workalendar/europe/netherlands.py
@@ -161,7 +161,7 @@ class NetherlandsWithSchoolHolidays(Netherlands):
             if self.region in FALL_HOLIDAYS_EARLY_REGIONS[year]:
                 start = start - timedelta(weeks=1)
         except KeyError:
-            raise NotImplementedError("Unknown fall holidays for %d." % year)
+            raise NotImplementedError(f"Unknown fall holidays for {year}.")
 
         return [
             (start + timedelta(days=i), "Fall holiday") for i in range(n_days)
@@ -250,7 +250,7 @@ class NetherlandsWithSchoolHolidays(Netherlands):
             if self.region in SPRING_HOLIDAYS_EARLY_REGIONS[year]:
                 start = start - timedelta(weeks=1)
         except KeyError:
-            raise NotImplementedError("Unknown spring holidays for %d." % year)
+            raise NotImplementedError(f"Unknown spring holidays for {year}.")
 
         return [
             (
@@ -314,14 +314,14 @@ class NetherlandsWithSchoolHolidays(Netherlands):
             if self.region in SUMMER_HOLIDAYS_EARLY_REGIONS[year]:
                 start = start - timedelta(weeks=1)
         except KeyError:
-            raise NotImplementedError("Unknown summer holidays for %d." % year)
+            raise NotImplementedError(f"Unknown summer holidays for {year}.")
 
         # Some regions have their summer holiday 1 week later
         try:
             if self.region in SUMMER_HOLIDAYS_LATE_REGIONS[year]:
                 start = start + timedelta(weeks=1)
         except KeyError:
-            raise NotImplementedError("Unknown summer holidays for %d." % year)
+            raise NotImplementedError(f"Unknown summer holidays for {year}.")
 
         return [
             (

--- a/workalendar/tests/__init__.py
+++ b/workalendar/tests/__init__.py
@@ -57,7 +57,7 @@ class GenericCalendarTest(CoreCalendarTest):
         temp_dir = Path(tempfile.gettempdir()) / "failed_ical_tests"
         temp_dir.mkdir(parents=True, exist_ok=True)
         _, test_file_name = tempfile.mkstemp(
-            prefix="%s_" % self.cal_class.__name__,
+            prefix=f"{self.cal_class.__name__}_",
             suffix=".ics",
             dir=temp_dir,
         )
@@ -78,7 +78,7 @@ class GenericCalendarTest(CoreCalendarTest):
             # check new year
             assert ics_file.readline() == 'BEGIN:VEVENT\n'
             first_event_name = holidays[0][1]
-            assert ics_file.readline() == 'SUMMARY:%s\n' % first_event_name
+            assert ics_file.readline() == f'SUMMARY:{first_event_name}\n'
             if self.test_include_january_1st:
                 assert ics_file.readline() == 'DTSTART;VALUE=DATE:20190101\n'
                 assert ics_file.readline().startswith(

--- a/workalendar/usa/core.py
+++ b/workalendar/usa/core.py
@@ -85,10 +85,10 @@ class UnitedStates(WesternCalendar):
                 continue
             if day.weekday() == SAT:
                 new_holidays.append((day - timedelta(days=1),
-                                     label + " (Observed)"))
+                                     f"{label} (Observed)"))
             elif day.weekday() == SUN:
                 new_holidays.append((day + timedelta(days=1),
-                                     label + " (Observed)"))
+                                     f"{label} (Observed)"))
 
         # If year+1 January the 1st is on SAT, add the FRI before to observed
         if date(year + 1, 1, 1).weekday() == SAT:


### PR DESCRIPTION
Since we're at Python 3.6+, we can use the f-strings instead of the `%` and `.format` calls.