### PR TITLE
Use integers for units division

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 - Update Singapore for range from 2022 to 2030 (Deepavali), by @hprobotic
 - Use f-string for string formatting, thx to @eumiro (#605)
 - Simplify collections handling, thx to @eumiro (#606)
+- Use integers for time units divisions, thx to @eumiro
 
 ## v14.1.0 (2020-12-10)
 

--- a/workalendar/astronomy.py
+++ b/workalendar/astronomy.py
@@ -11,10 +11,10 @@ from datetime import date, timedelta
 
 # Parameter for the newton method to converge towards the closest solution
 # to the function. By default it'll be an approximation of a 10th of a second.
-hour = 1. / 24.
-minute = hour / 60.
-second = minute / 60.
-newton_precision = second / 10.
+hour = 1 / 24
+minute = hour / 60
+second = minute / 60
+newton_precision = second / 10
 
 
 def calculate_equinoxes(year, timezone='UTC'):


### PR DESCRIPTION
Numbers in time units divisions are generally integers (24/60/60), so they can be defined that way and Python3 will convert the division to a float automatically.

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
