### PR TITLE
Replace pytz with zoneinfo (backports.zoneinfo for Python 3.6–3.8)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 - Update Singapore for range from 2022 to 2030 (Deepavali), by @hprobotic
 - Use f-string for string formatting, thx to @eumiro (#605)
 - Simplify collections handling, thx to @eumiro (#606)
+- Replace pytz with (backports.)zoneinfo, thx to @eumiro
 
 ## v14.1.0 (2020-12-10)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     skyfield-data
     python-dateutil
     lunardate
-    pytz
+    backports.zoneinfo;python_version<"3.9"
     pyCalverter
     pyluach
     setuptools>=1.0

--- a/workalendar/astronomy.py
+++ b/workalendar/astronomy.py
@@ -2,7 +2,10 @@
 Astronomical functions
 """
 from math import pi, radians, tau
-import pytz
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # pre-3.9
+    from backports.zoneinfo import ZoneInfo
 from skyfield.api import Loader
 from skyfield import almanac
 from skyfield_data import get_skyfield_data_path
@@ -19,7 +22,7 @@ newton_precision = second / 10.
 
 def calculate_equinoxes(year, timezone='UTC'):
     """ calculate equinox with time zone """
-    tz = pytz.timezone(timezone)
+    tz = ZoneInfo(timezone)
 
     load = Loader(get_skyfield_data_path())
     ts = load.timescale()
@@ -80,7 +83,7 @@ def solar_term(year, degrees, timezone='UTC'):
     earth = planets['earth']
     sun = planets['sun']
     ts = load.timescale()
-    tz = pytz.timezone(timezone)
+    tz = ZoneInfo(timezone)
 
     jan_first = ts.utc(date(year, 1, 1))
     current_longitude = get_current_longitude(jan_first, earth, sun)


### PR DESCRIPTION
Python 3.9 brings `zoneinfo` in its stdlib and it is also distributed as `backports.zoneinfo` for Python 3.6–3.8. Replace `pytz` with it.

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
