### PR TITLE
Netherlands school holidays refactor

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,9 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Small fixes in Netherlands School calendars (#619).
+- New method available in `core` module: `Calendar.get_iso_week_date()` to find the weekday X of the week number Y (#619).
+- Improve Netherlands coverage (#546, #619).
 
 ## v14.3.0 (2021-01-15)
 

--- a/workalendar/tests/test_core.py
+++ b/workalendar/tests/test_core.py
@@ -8,6 +8,7 @@ import pandas
 from . import CoreCalendarTest
 from ..core import (
     MON, TUE, THU, FRI, WED, SAT, SUN,
+    ISO_TUE, ISO_FRI,
     Calendar, LunarMixin, WesternCalendar,
     CalverterMixin, IslamicMixin, JalaliMixin,
     daterange,
@@ -103,6 +104,34 @@ class CalendarTest(CoreCalendarTest):
         self.assertEqual(
             Calendar.get_first_weekday_after(date(2015, 4, 14), TUE),
             date(2015, 4, 14)
+        )
+
+    def test_get_iso_week_date(self):
+        # Find the MON of the week 1 in 2021
+        self.assertEqual(
+            Calendar.get_iso_week_date(2021, 1),
+            date(2021, 1, 4)
+        )
+        # Find the FRI of the week 1 in 2021
+        self.assertEqual(
+            Calendar.get_iso_week_date(2021, 1, ISO_FRI),
+            date(2021, 1, 8)
+        )
+
+        # Find the TUE of the week 44 in 2021
+        self.assertEqual(
+            Calendar.get_iso_week_date(2021, 44, ISO_TUE),
+            date(2021, 11, 2)
+        )
+
+    # Remove this test when dropping support for Python 3.7
+    @patch('workalendar.core.sys')
+    def test_get_iso_week_date_patched(self, mock_sys):
+        # The Python 3.6-3.7 backport should always work
+        mock_sys.version_info = (3, 6, 0)
+        self.assertEqual(
+            Calendar.get_iso_week_date(2021, 44, ISO_TUE),
+            date(2021, 11, 2)
         )
 
 

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -1,8 +1,9 @@
 from datetime import date, timedelta, datetime
 from collections import Counter
+from unittest import TestCase
 
 from . import GenericCalendarTest
-from ..core import daterange
+from ..core import daterange, ISO_SAT
 from ..europe import (
     Austria,
     Bulgaria,
@@ -41,6 +42,14 @@ from ..europe import (
     UnitedKingdom,
     UnitedKingdomNorthernIreland,
     EuropeanCentralBank,
+)
+
+
+# Tests dedicated to Netherlands School holidays
+from ..europe.netherlands import (
+    SPRING_HOLIDAYS_EARLY_REGIONS,
+    SUMMER_HOLIDAYS_EARLY_REGIONS,
+    SUMMER_HOLIDAYS_LATE_REGIONS,
 )
 
 
@@ -994,27 +1003,42 @@ class NetherlandsTest(GenericCalendarTest):
         self.assertNotIn(date(2016, 12, 31), holidays)
 
 
-class NetherlandsWithSchoolHolidaysWithInvalidRegionTest(GenericCalendarTest):
+class NetherlandsWithSchoolHolidaysWithInvalidRegionTest(TestCase):
 
-    cal_class = NetherlandsWithSchoolHolidays
-    kwargs = dict(region="east")
-
-    def setUp(self):
+    def test_instanciate_invalid_region(self):
         with self.assertRaises(ValueError) as cm:
-            super().setUp()
+            NetherlandsWithSchoolHolidays(region="east")
         assert "Set region" in str(cm.exception)
 
-    def test_weekend_days(self):
-        """Skip test as calendar setup is expected to fail"""
-        pass
+        with self.assertRaises(ValueError) as cm:
+            NetherlandsWithSchoolHolidays(region="")
+        assert "Set region" in str(cm.exception)
 
-    def test_january_1st(self):
-        """Skip test as calendar setup is expected to fail"""
-        pass
+    def test_instanciate_no_region(self):
+        with self.assertRaises(TypeError) as cm:
+            NetherlandsWithSchoolHolidays()
+        assert "missing 1 required positional argument" in str(cm.exception)
 
-    def test_ical_export(self):
-        """Skip test as calendar setup is expected to fail"""
-        pass
+
+class NetherlandsWithSchoolHolidaysInvalidRanges(TestCase):
+
+    def test_spring_holidays_invalid_range(self):
+        max_year = max(SPRING_HOLIDAYS_EARLY_REGIONS)
+        calendar = NetherlandsWithSchoolHolidays(region="north")
+        with self.assertRaises(NotImplementedError):
+            calendar.get_spring_holidays(max_year + 1)
+
+    def test_summer_early_holidays_invalid_range(self):
+        max_year = max(SUMMER_HOLIDAYS_EARLY_REGIONS)
+        calendar = NetherlandsWithSchoolHolidays(region="north")
+        with self.assertRaises(NotImplementedError):
+            calendar.get_summer_holidays(max_year + 1)
+
+    def test_summer_late_holidays_invalid_range(self):
+        max_year = max(SUMMER_HOLIDAYS_LATE_REGIONS)
+        calendar = NetherlandsWithSchoolHolidays(region="north")
+        with self.assertRaises(NotImplementedError):
+            calendar.get_summer_holidays(max_year + 1)
 
 
 class NetherlandsNorthWithSchoolHolidaysTest(GenericCalendarTest):
@@ -1108,6 +1132,49 @@ class NetherlandsNorthWithSchoolHolidaysTest(GenericCalendarTest):
                 "Christmas holiday",
                 holidays[christmas_holiday_start + timedelta(days=d)],
             )
+
+    def test_may_holidays_exceptions(self):
+        # In 2017, May holidays started on week 17 instead of 18
+
+        # First, make sure we have a coherent date for 2021
+        may_holidays_2021 = self.cal.get_may_holidays(2021)
+        start_2021 = may_holidays_2021[0][0]
+        self.assertEqual(
+            start_2021,
+            # Preceding SAT
+            self.cal.get_iso_week_date(2021, 18 - 1, ISO_SAT)
+        )
+
+        # Then, get the start date for 2017
+        may_holidays_2017 = self.cal.get_may_holidays(2017)
+        start_2017 = may_holidays_2017[0][0]
+        self.assertEqual(
+            start_2017,
+            # Preceding SAT
+            self.cal.get_iso_week_date(2017, 17 - 1, ISO_SAT)
+        )
+
+    def test_fall_holidays_exceptions(self):
+        # In 2024, May holidays start on week 44 instead of 43
+
+        # First, make sure we have a coherent date for 2019
+        # (using 2019 to avoid being in FALL_HOLIDAYS_EARLY_REGIONS)
+        fall_holidays_2019 = self.cal.get_fall_holidays(2019)
+        start_2019 = fall_holidays_2019[0][0]
+        self.assertEqual(
+            start_2019,
+            # Preceding SAT
+            self.cal.get_iso_week_date(2019, 43 - 1, ISO_SAT)
+        )
+
+        # Then, get the start date for 2024
+        fall_holidays_2024 = self.cal.get_fall_holidays(2024)
+        start_2024 = fall_holidays_2024[0][0]
+        self.assertEqual(
+            start_2024,
+            # Preceding SAT
+            self.cal.get_iso_week_date(2024, 44 - 1, ISO_SAT)
+        )
 
 
 class NetherlandsMiddleWithSchoolHolidaysTest(GenericCalendarTest):


### PR DESCRIPTION
## Changes

- Small fixes in Netherlands School calendars (#619).
- New method available in `core` module: `Calendar.get_iso_week_date()` to find the weekday X of the week number Y (#619).
- Improve Netherlands coverage (#546, #619).

## Tasks

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
