### PR TITLE
Temporary downgrade of `pyupgrade` to fix the `pyup_dirs`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 - Improve Netherlands coverage (#546, #619).
 - Improve Russia coverage (#546).
 - Improve USA calendar coverage by removing a method that wasn't used anyways (`get_washington_birthday_december()`). The method is implemented in both Indiana and Georgia State calendars, and is specific for each state, even if they look very similar (#546).
+- Temporary downgrade of `pyupgrade` to fix the `pyup_dirs`.
 
 ## v14.3.0 (2021-01-15)
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ commands = flake8 workalendar
 
 [testenv:pyupgrade]
 deps =
+    pyupgrade<2.8
     pyupgrade-directories
 commands_pre =
 skip_install = true


### PR DESCRIPTION
refs https://github.com/domdfcoding/pyupgrade-directories/issues/13

- [x] Tests are green
- [x] Changelog amended with a mention describing your changes.
