### PR TITLE
Replace pytz with zoneinfo (backports.zoneinfo for Python 3.6–3.8)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,8 @@
 - Temporary downgrade of `pyupgrade` to fix the `pyup_dirs`.
 - Improve the `astronomy.py` module coverage (#546).
 - Improve coverage for the `tests/__init__.py` module (#546). *Note:* system-dependant test branch (if Windows) won't be counted for coverage.
+- Replace pytz with `(backports.)zoneinfo`, thx to @eumiro (#614)
+- Documented the different (in)compatibilities due to the use of `zoneinfo` (#614).
 
 ## v14.3.0 (2021-01-15)
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,17 @@ For a more complete documentation and advanced usage, go to [the official workal
 
 ## External dependencies
 
+**Workalendar will require you to use Python 3.6+.**
+
 Workalendar is tested on Python 3.6, 3.7, 3.8, 3.9, and on Linux (Ubuntu), Mac OS and Windows using Github actions.
 
-**Incompatibility:** Workalendar will require you to use Python 3.6+.
+### Conditional dependencies
 
-If you're using wheels, you should be fine without having to install extra system packages. As of `v7.0.0`, we have dropped `ephem` as a dependency for computing astronomical ephemeris in favor of `skyfield`. So if you had any trouble because of this new dependency, during the installation or at runtime, [do not hesitate to file an issue](https://github.com/peopledoc/workalendar/issues/).
+As of [NEXT RELEASE]:
+
+* If you're using \*Nix and Python 3.6, 3.7, 3.8, the package `backports.zoneinfo` is required
+* If you're using Windows and Python 3.6, 3.7, 3.8, the package `tzdata` is *also* a requirement (with the `backports.zoneinfo`).
+* If you're using Python 3.9+, the stdlib `zoneinfo` package will be used.
 
 ## Tests
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,8 @@ install_requires =
     skyfield-data
     python-dateutil
     lunardate
-    pytz
+    backports.zoneinfo;python_version<"3.9"
+    tzdata;platform_system=="Windows"
     pyCalverter
     pyluach
     setuptools>=1.0

--- a/workalendar/astronomy.py
+++ b/workalendar/astronomy.py
@@ -2,7 +2,11 @@
 Astronomical functions
 """
 from math import pi, radians, tau
-import pytz
+try:
+    # As of Python 3.9, included in the stdlib
+    from zoneinfo import ZoneInfo
+except ImportError:  # pre-3.9
+    from backports.zoneinfo import ZoneInfo
 from skyfield.api import Loader
 from skyfield import almanac
 from skyfield_data import get_skyfield_data_path
@@ -19,7 +23,7 @@ newton_precision = second / 10
 
 def calculate_equinoxes(year, timezone='UTC'):
     """ calculate equinox with time zone """
-    tz = pytz.timezone(timezone)
+    tz = ZoneInfo(timezone)
 
     load = Loader(get_skyfield_data_path())
     ts = load.timescale()
@@ -98,7 +102,7 @@ def solar_term(year, degrees, timezone='UTC'):
     earth = planets['earth']
     sun = planets['sun']
     ts = load.timescale()
-    tz = pytz.timezone(timezone)
+    tz = ZoneInfo(timezone)
 
     jan_first = ts.utc(date(year, 1, 1))
     current_longitude = get_current_longitude(jan_first, earth, sun)


### PR DESCRIPTION
superseeds, and thus, closes #614

- [x] Tests that there's no regression
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
