### PR TITLE
v15.0.0 Release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,17 +1,27 @@
 # CHANGELOG
 
-## master (unreleased)
+## v15.0.0 (2021-02-19)
+
+### Major changes
+
+- API: New method available in `core` module: `Calendar.get_iso_week_date()` to find the weekday X of the week number Y (#619).
+- Requirements: Replace pytz with `(backports.)zoneinfo`, thx to @eumiro (#614)
+- Doc: Documented the different (in)compatibilities due to the use of `zoneinfo` (#614).
+
+### Minor changes
+
+#### Bugfixes
 
 - Small fixes in Netherlands School calendars (#619).
-- New method available in `core` module: `Calendar.get_iso_week_date()` to find the weekday X of the week number Y (#619).
+- Temporary downgrade of `pyupgrade` to fix the `pyup_dirs`.
+
+#### Improving test coverage
+
 - Improve Netherlands coverage (#546, #619).
 - Improve Russia coverage (#546).
 - Improve USA calendar coverage by removing a method that wasn't used anyways (`get_washington_birthday_december()`). The method is implemented in both Indiana and Georgia State calendars, and is specific for each state, even if they look very similar (#546).
-- Temporary downgrade of `pyupgrade` to fix the `pyup_dirs`.
 - Improve the `astronomy.py` module coverage (#546).
 - Improve coverage for the `tests/__init__.py` module (#546). *Note:* system-dependant test branch (if Windows) won't be counted for coverage.
-- Replace pytz with `(backports.)zoneinfo`, thx to @eumiro (#614)
-- Documented the different (in)compatibilities due to the use of `zoneinfo` (#614).
 
 ## v14.3.0 (2021-01-15)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## master (unreleased)
+
+Nothing here yet.
+
 ## v15.0.0 (2021-02-19)
 
 ### Major changes

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Workalendar is tested on Python 3.6, 3.7, 3.8, 3.9, and on Linux (Ubuntu), Mac O
 
 ### Conditional dependencies
 
-As of [NEXT RELEASE]:
+As of v15.0.0:
 
 * If you're using \*Nix and Python 3.6, 3.7, 3.8, the package `backports.zoneinfo` is required
 * If you're using Windows and Python 3.6, 3.7, 3.8, the package `tzdata` is *also* a requirement (with the `backports.zoneinfo`).

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = workalendar
-version = 15.0.0
+version = 15.1.0.dev0
 description = Worldwide holidays and working days helper and toolkit.
 author = Bruno Bord
 author_email = bruno.bord@people-doc.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = workalendar
-version = 14.4.0.dev0
+version = 15.0.0
 description = Worldwide holidays and working days helper and toolkit.
 author = Bruno Bord
 author_email = bruno.bord@people-doc.com


### PR DESCRIPTION
**Major changes**

- API: New method available in `core` module: `Calendar.get_iso_week_date()` to find the weekday X of the week number Y (#619).
- Requirements: Replace pytz with `(backports.)zoneinfo`, thx to @eumiro (#614)
- Doc: Documented the different (in)compatibilities due to the use of `zoneinfo` (#614).

**Minor changes**

*Bugfix*

- Small fixes in Netherlands School calendars (#619).
- Temporary downgrade of `pyupgrade` to fix the `pyup_dirs`.

*Improving test coverage*

- Improve Netherlands coverage (#546, #619).
- Improve Russia coverage (#546).
- Improve USA calendar coverage by removing a method that wasn't used anyways (`get_washington_birthday_december()`). The method is implemented in both Indiana and Georgia State calendars, and is specific for each state, even if they look very similar (#546).
- Improve the `astronomy.py` module coverage (#546).
- Improve coverage for the `tests/__init__.py` module (#546). *Note:* system-dependant test branch (if Windows) won't be counted for coverage.

## Actions

- Commit for the tag:
    - [x] Edit version in setup.cfg
    - [x] Add version in Changelog.md ; trim things
    - [x] Push & wait for the tests to be green
    - [x] tag me.
    - [x] build sdist + wheel packages (``make package``)
- Back to dev commit:
    - [x] Edit version in setup.cfg
    - [x] Add the "master / nothing to see here" in Changelog.md
    - [x] Push & wait for the tests to be green
- [ ] Merge --ff
- Github stuff
    - [ ] Push tag in Github
    - [ ] Edit release on Github using the changelog.
    - [ ] Delete branch
- [ ] upload release on PyPI using ``twine``
- [ ] (*optional*) Make feeback on the various PR or issues.
