### PR TITLE
Hotfix: Taiwan exceptional working days in 2021

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - Hotfix: Taiwan exceptional working day on February, 20th 2021 (#628).
+- Hotfix: September 11th is a working day in Taiwan (#628).
 
 ## v15.0.0 (2021-02-19)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+- Hotfix: Taiwan exceptional working day on February, 20th 2021 (#628).
 
 ## v15.0.0 (2021-02-19)
 

--- a/workalendar/asia/taiwan.py
+++ b/workalendar/asia/taiwan.py
@@ -18,7 +18,7 @@ class Taiwan(ChineseNewYearCalendar):
 
     def is_working_day(self, day, *args, **kwargs):
         day = cleaned_date(day)
-        if day == date(2021, 2, 20):
+        if day in (date(2021, 2, 20), date(2021, 9, 11)):
             return True
         return super().is_working_day(day, *args, **kwargs)
 

--- a/workalendar/asia/taiwan.py
+++ b/workalendar/asia/taiwan.py
@@ -1,4 +1,6 @@
-from ..core import ChineseNewYearCalendar
+from datetime import date
+
+from ..core import ChineseNewYearCalendar, cleaned_date
 from ..astronomy import solar_term
 from ..registry_tools import iso_register
 
@@ -13,6 +15,12 @@ class Taiwan(ChineseNewYearCalendar):
     )
     include_chinese_new_year_eve = True
     include_chinese_second_day = True
+
+    def is_working_day(self, day, *args, **kwargs):
+        day = cleaned_date(day)
+        if day == date(2021, 2, 20):
+            return True
+        return super().is_working_day(day, *args, **kwargs)
 
     def get_variable_days(self, year):
         days = super().get_variable_days(year)

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -612,7 +612,7 @@ class TaiwanTest(GenericCalendarTest):
         self.assertIn(date(2013, 4, 4), self.cal.holidays_set(2013))
         self.assertIn(date(2014, 4, 4), self.cal.holidays_set(2014))
 
-    def test_extra_day_2021(self):
+    def test_extra_day_2021_february(self):
         extra_day_feb_20 = date(2021, 2, 20)
         self.assertTrue(self.cal.is_working_day(extra_day_feb_20))
         # Compute deltas with the extra-working day...
@@ -621,6 +621,16 @@ class TaiwanTest(GenericCalendarTest):
         )
         # Should've been on 26th, albeit the 20th
         self.assertEqual(five_days_after, date(2021, 2, 25))
+
+    def test_extra_day_2021_september(self):
+        extra_day_sept_11 = date(2021, 9, 11)
+        self.assertTrue(self.cal.is_working_day(extra_day_sept_11))
+        # Compute deltas with the extra-working day...
+        five_days_after = self.cal.add_working_days(
+            date(2021, 9, 10), 5
+        )
+        # Should've been on 17th, albeit the 11th
+        self.assertEqual(five_days_after, date(2021, 9, 16))
 
 
 class IsraelTest(GenericCalendarTest):

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -612,6 +612,16 @@ class TaiwanTest(GenericCalendarTest):
         self.assertIn(date(2013, 4, 4), self.cal.holidays_set(2013))
         self.assertIn(date(2014, 4, 4), self.cal.holidays_set(2014))
 
+    def test_extra_day_2021(self):
+        extra_day_feb_20 = date(2021, 2, 20)
+        self.assertTrue(self.cal.is_working_day(extra_day_feb_20))
+        # Compute deltas with the extra-working day...
+        five_days_after = self.cal.add_working_days(
+            date(2021, 2, 19), 5
+        )
+        # Should've been on 26th, albeit the 20th
+        self.assertEqual(five_days_after, date(2021, 2, 25))
+
 
 class IsraelTest(GenericCalendarTest):
 


### PR DESCRIPTION
refs #628 (will be closed after the HF release)

Two extra-working days in 2021

* February, 20th
* September 11th,

**checklist**

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
