### PR TITLE
Requirements: Unpin `pyupgrade` library

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - Bugfix: USA calendar would take the `shift_exceptions` into account, even if the exceptions are set in the next or previous year (#610).
+- Requirements: Unpin `pyupgrade` library (#634).
 
 ## v15.0.1 (2021-02-26)
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands = flake8 workalendar
 
 [testenv:pyupgrade]
 deps =
-    pyupgrade<2.8
+    pyupgrade
     pyupgrade-directories
 commands_pre =
 skip_install = true


### PR DESCRIPTION
refs #634


- [x] No regression in linters tests
- [x] Changelog amended with a mention describing your changes.
