### PR TITLE
v15.0.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## master (unreleased)
+## v15.0.2 (2021-03-05)
 
 - Bugfix: USA calendar would take the `shift_exceptions` into account, even if the exceptions are set in the next or previous year (#610).
 - Requirements: Unpin `pyupgrade` library (#634).

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## master (unreleased)
+
+Nothing to see here.
+
 ## v15.0.2 (2021-03-05)
 
 - Bugfix: USA calendar would take the `shift_exceptions` into account, even if the exceptions are set in the next or previous year (#610).

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = workalendar
-version = 15.0.2
+version = 15.1.0.dev2
 description = Worldwide holidays and working days helper and toolkit.
 author = Bruno Bord
 author_email = bruno.bord@people-doc.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = workalendar
-version = 15.1.0.dev1
+version = 15.0.2
 description = Worldwide holidays and working days helper and toolkit.
 author = Bruno Bord
 author_email = bruno.bord@people-doc.com


### PR DESCRIPTION
- Bugfix: USA calendar would take the `shift_exceptions` into account, even if the exceptions are set in the next or previous year (#610).
- Requirements: Unpin `pyupgrade` library (#634).

### release management

- Commit for the tag:
    - [x] Edit version in setup.cfg
    - [x] Add version in Changelog.md ; trim things
    - [x] Push & wait for the tests to be green
    - [x] tag me.
    - [x] build sdist + wheel packages (``make package``)
- Back to dev commit:
    - [x] Edit version in setup.cfg
    - [x] Add the "master / nothing to see here" in Changelog.md
    - [x] Push & wait for the tests to be green
- [ ] Merge --ff
- Github stuff
    - [ ] Push tag in Github
    - [ ] Edit release on Github using the changelog.
    - [ ] Delete branch
- [ ] upload release on PyPI using ``twine``
- [ ] (*optional*) Make feeback on the various PR or issues.


This PR will close #610