### PR TITLE
Add St John the Baptist day for Catalonian calendar

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing to see here yet.
+- Fix Catalonian calendar: add missing St John the Baptist public holiday
 
 ## v15.1.0 (2021-03-12)
 

--- a/workalendar/europe/spain.py
+++ b/workalendar/europe/spain.py
@@ -83,6 +83,7 @@ class Catalonia(Spain):
 
     FIXED_HOLIDAYS = Spain.FIXED_HOLIDAYS + (
         (9, 11, "Diada nacional de Catalunya"),
+        (6, 24, "La revetlla de Sant Joan, Nit de Sant Joan"),
     )
 
 

--- a/workalendar/tests/test_spain.py
+++ b/workalendar/tests/test_spain.py
@@ -138,7 +138,7 @@ class CataloniaTest(SpainTest):
         # La revetlla de Sant Joan, Nit de Sant Joan
         self.assertIn(date(2015, 6, 24), holidays)
         self.assertIn(date(2015, 12, 26), holidays)  # Sant Esteve
-        self.assertEqual(len(holidays), 13)
+        self.assertEqual(len(holidays), 14)
 
     def test_region_year_2016(self):
         holidays = self.cal.holidays_set(2016)
@@ -148,7 +148,7 @@ class CataloniaTest(SpainTest):
         # La revetlla de Sant Joan, Nit de Sant Joan
         self.assertIn(date(2016, 6, 24), holidays)
         self.assertIn(date(2016, 12, 26), holidays)  # Sant Esteve
-        self.assertEqual(len(holidays), 13)
+        self.assertEqual(len(holidays), 14)
 
     def test_boxing_day_label(self):
         holidays = self.cal.holidays(2020)

--- a/workalendar/tests/test_spain.py
+++ b/workalendar/tests/test_spain.py
@@ -135,6 +135,8 @@ class CataloniaTest(SpainTest):
         self.assertIn(date(2015, 4, 6), holidays)  # Easter Monday
         # Diada nacional de Catalunya
         self.assertIn(date(2015, 9, 11), holidays)
+        # La revetlla de Sant Joan, Nit de Sant Joan
+        self.assertIn(date(2015, 6, 24), holidays)
         self.assertIn(date(2015, 12, 26), holidays)  # Sant Esteve
         self.assertEqual(len(holidays), 13)
 
@@ -143,6 +145,8 @@ class CataloniaTest(SpainTest):
         self.assertIn(date(2016, 3, 28), holidays)  # Easter Monday
         # Diada nacional de Catalunya
         self.assertIn(date(2016, 9, 11), holidays)
+        # La revetlla de Sant Joan, Nit de Sant Joan
+        self.assertIn(date(2016, 6, 24), holidays)
         self.assertIn(date(2016, 12, 26), holidays)  # Sant Esteve
         self.assertEqual(len(holidays), 13)
 


### PR DESCRIPTION
Adds missing public holiday for Catalonian calendar, see here for reference: https://www.timeanddate.com/holidays/spain/sant-joan

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
