### PR TITLE
Update Cuiaba-Brazil holidays

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing to see here yet.
+- Fixed Cuiaba City calendar (Brazil), adding Easter Sunday, Corpus Christi and Good Friday, thx @leogregianin (#642).
 
 ## v15.1.0 (2021-03-12)
 

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -462,6 +462,10 @@ class BrazilCuiabaCity(BrazilMatoGrosso):
     FIXED_HOLIDAYS = BrazilMatoGrosso.FIXED_HOLIDAYS + (
         (4, 8, "Aniversário de Cuiabá"),
     )
+    include_easter_sunday = True
+    include_corpus_christi = True
+    include_good_friday = True
+    good_friday_label = "Sexta-feira da Paixão"
 
 
 class BrazilBelemCity(BrazilPara):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -676,6 +676,15 @@ class BrazilCuiabaCityTest(BrazilMatoGrossoTest):
         # Fixed days
         # Aniversário de Cuiabá
         self.assertIn(date(2017, 4, 8), holidays)
+        self.assertIn(date(2017, 4, 14), holidays)  # good_friday
+        self.assertIn(date(2017, 4, 16), holidays)  # easter_sunday
+        self.assertIn(date(2017, 6, 15), holidays)  # corpus_christi
+
+    def test_good_friday_label(self):
+        holidays = self.cal.holidays(2017)
+        holidays_dict = dict(holidays)
+        good_friday_label = holidays_dict[date(2017, 4, 14)]
+        self.assertEqual(good_friday_label, "Sexta-feira da Paixão")
 
 
 class BrazilBelemCityTest(BrazilParaTest):


### PR DESCRIPTION
Adding Easter Sunday, Corpus Christi and Good Friday.

This PR amends and would close #642 when it'll be merged.

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
